### PR TITLE
BF-60: JS function corrupts after round-trip back from a Python function

### DIFF
--- a/src/jsTypeFactory.cc
+++ b/src/jsTypeFactory.cc
@@ -158,8 +158,8 @@ bool callPyFunc(JSContext *cx, unsigned int argc, JS::Value *vp) {
   JS::Value pyFuncVal = js::GetFunctionNativeReserved(&(callargs.callee()), 0);
   PyObject *pyFunc = (PyObject *)(pyFuncVal.toPrivate());
 
-  JS::RootedObject thisv(cx);
-  JS_ValueToObject(cx, callargs.thisv(), &thisv);
+  JS::RootedObject *thisv = new JS::RootedObject(cx);
+  JS_ValueToObject(cx, callargs.thisv(), thisv);
 
   if (!callargs.length()) {
     PyObject *pyRval = PyObject_CallNoArgs(pyFunc);
@@ -171,8 +171,8 @@ bool callPyFunc(JSContext *cx, unsigned int argc, JS::Value *vp) {
   // populate python args tuple
   PyObject *pyArgs = PyTuple_New(callargs.length());
   for (size_t i = 0; i < callargs.length(); i++) {
-    JS::RootedValue jsArg = JS::RootedValue(cx, callargs[i]);
-    PyType *pyArg = (pyTypeFactory(cx, &thisv, &jsArg));
+    JS::RootedValue *jsArg = new JS::RootedValue(cx, callargs[i]);
+    PyType *pyArg = pyTypeFactory(cx, thisv, jsArg);
     PyTuple_SetItem(pyArgs, i, pyArg->getPyObject());
   }
 

--- a/tests/python/test_pythonmonkey_eval.py
+++ b/tests/python/test_pythonmonkey_eval.py
@@ -590,6 +590,14 @@ def test_eval_functions_ucs4_string_args():
         
         assert pm.asUCS4(concatenate(string1, string2)) == (string1 + string2)
 
+def test_eval_functions_roundtrip():
+    # BF-60 https://github.com/Distributive-Network/PythonMonkey/pull/18
+    def ident(x):
+        return x
+    js_fn_back = pm.eval("(py_fn) => py_fn(()=>{ return 'YYZ' })")(ident)
+    # pm.collect() # TODO: to be fixed in BF-59
+    assert "YYZ" == js_fn_back()
+
 def test_eval_functions_pyfunctions_ints():
     caller = pm.eval("(func, param1, param2) => { return func(param1, param2) }")
     def add(a, b):


### PR DESCRIPTION
Before the patch
```py
def ident(x):
  print(x()) # 123.0
  return x
a = pm.eval("""(py_fn) => {
  const fn = py_fn(()=>{ return 123 })
  fn instanceof Function // true
  fn() // ??? TypeError: fn is not a function
  return fn
}""")(ident)
print(a()) #segfault
```

After patch
![](https://user-images.githubusercontent.com/16057139/234717899-8695c7a8-9bba-47fc-9f58-ebf4f89172c3.png)

---

This pull request resolves the following internal ticket:
* https://distributive.atlassian.net/browse/BF2-60