### PR TITLE
Fix/spidermonkey-build: SpiderMonkey build system breaks on Python 3.11

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,6 +10,7 @@ on:
 jobs:
   test-suite:
     strategy:
+      fail-fast: false
       matrix:
         os: [ 'ubuntu-latest' ] # , 'windows-latest', 'macos-latest' ]
         python_version: [ '3.9', '3.10', '3.11' ]

--- a/setup.sh
+++ b/setup.sh
@@ -19,6 +19,10 @@ tar xf firefox-102.2.0esr.source.tar.xz
 echo "Done downloading spidermonkey source code"
 
 echo "Building spidermonkey"
+cd firefox-102.2.0/python/mozbuild/mozbuild
+# the build system breaks on Python 3.11 (`io.open()` no longer accepts 'U' in the file mode)
+sed -i 's/"rU"/"r"/g' util.py
+cd -
 cd firefox-102.2.0/js
 sed -i 's/bool Unbox/JS_PUBLIC_API bool Unbox/g' ./public/Class.h           # need to manually add JS_PUBLIC_API to js::Unbox until it gets fixed in Spidermonkey
 sed -i 's/bool js::Unbox/JS_PUBLIC_API bool js::Unbox/g' ./src/vm/JSObject.cpp  # same here

--- a/setup.sh
+++ b/setup.sh
@@ -21,7 +21,7 @@ echo "Done downloading spidermonkey source code"
 echo "Building spidermonkey"
 cd firefox-102.2.0/python/mozbuild/mozbuild
 # the build system breaks on Python 3.11 (`io.open()` no longer accepts 'U' in the file mode)
-sed -i 's/"rU"/"r"/g' util.py
+sed -i 's/"rU"/"r"/g' util.py preprocessor.py action/process_define_files.py backend/base.py
 cd -
 cd firefox-102.2.0/js
 sed -i 's/bool Unbox/JS_PUBLIC_API bool Unbox/g' ./public/Class.h           # need to manually add JS_PUBLIC_API to js::Unbox until it gets fixed in Spidermonkey


### PR DESCRIPTION
https://github.com/Distributive-Network/PythonMonkey/actions/runs/5084218550/jobs/9136227002#step:6:1102

---

https://docs.python.org/3/whatsnew/3.11.html#porting-to-python-3-11

> [open()](https://docs.python.org/3/library/functions.html#open), [io.open()](https://docs.python.org/3/library/io.html#io.open), [codecs.open()](https://docs.python.org/3/library/codecs.html#codecs.open) and [fileinput.FileInput](https://docs.python.org/3/library/fileinput.html#fileinput.FileInput) no longer accept 'U' (“universal newline”) in the file mode. In Python 3, “universal newline” mode is used by default whenever a file is opened in text mode, and the 'U' flag has been deprecated since Python 3.3. The [newline parameter](https://docs.python.org/3/library/functions.html#open-newline-parameter) to these functions controls how universal newlines work. (Contributed by Victor Stinner in [bpo-37330](https://bugs.python.org/issue?@action=redirect&bpo=37330).)
