### PR TITLE
CI: build using the correct Python version

### DIFF
--- a/.github/workflows/test-and-publish.yaml
+++ b/.github/workflows/test-and-publish.yaml
@@ -38,7 +38,6 @@ jobs:
         uses: actions/cache@v3
         with:
           path: |
-            ./build/*
             ./firefox-102.2.0/*
             ./_spidermonkey_install/*
           key: ${{ runner.os }}-spidermonkey


### PR DESCRIPTION
https://github.com/Distributive-Network/PythonMonkey/actions/runs/5115473014/jobs/9196841495?pr=24#step:8:18 fails because cmake is not using the correct version of Python to build `pythonmonkey.so`.

