### PR TITLE
CI: upload wheel as CI artifacts

### DIFF
--- a/.github/workflows/test-and-publish.yaml
+++ b/.github/workflows/test-and-publish.yaml
@@ -49,6 +49,11 @@ jobs:
           echo $(poetry run python --version)
           poetry build --format=wheel
           ls -lah ./dist/
+      - name: Upload wheel as CI artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: wheel-${{ github.run_id }}-${{ github.sha }}
+          path: ./dist/
       - name: google-tests
         run: |
           cd build
@@ -61,7 +66,7 @@ jobs:
       - name: google-tests-artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ github.job }}-${{ github.run_id }}-${{ github.sha }}
+          name: coverage-${{ github.run_id }}-${{ github.sha }}
           path: ./build/coverage.xml
       - name: Buid and Publish package
         if: ${{ success()  && github.event_name == 'push' && contains(github.ref, 'refs/tags/') }}


### PR DESCRIPTION
This would allow us to test the CI-built package locally, for any branch/commit.