### PR TITLE
Fix: python 3.12 bigint

### DIFF
--- a/src/IntType.cc
+++ b/src/IntType.cc
@@ -56,7 +56,7 @@ static inline bool PythonLong_IsNegative(const PyLongObject *op) {
   return (op->long_value.lv_tag & _PyLong_SIGN_MASK) == _PyLong_SIGN_NEGATIVE;
 #else // Python version is less than 3.12
   // see https://github.com/python/cpython/blob/v3.9.16/Objects/longobject.c#L977
-  ssize_t pyDigitCount = Py_SIZE(pyObject); // negative on negative numbers
+  ssize_t pyDigitCount = Py_SIZE(op); // negative on negative numbers
   return pyDigitCount < 0;
 #endif
 }

--- a/src/IntType.cc
+++ b/src/IntType.cc
@@ -41,7 +41,7 @@ static inline void PythonLong_SetSign(PyLongObject *op, int sign) {
 #else // Python version is less than 3.12
   // see https://github.com/python/cpython/blob/v3.9.16/Objects/longobject.c#L956
   ssize_t pyDigitCount = Py_SIZE(op);
-  Py_SET_SIZE(op, sign * pyDigitCount);
+  Py_SET_SIZE(op, sign * std::abs(pyDigitCount));
 #endif
 }
 

--- a/src/setSpiderMonkeyException.cc
+++ b/src/setSpiderMonkeyException.cc
@@ -30,6 +30,8 @@ void setSpiderMonkeyException(JSContext *cx) {
     PyErr_SetString(SpiderMonkeyError, "Spidermonkey set an exception, but was unable to retrieve it.");
     return;
   }
+  JS_ClearPendingException(cx);
+
   JS::ErrorReportBuilder reportBuilder(cx);
   if (!reportBuilder.init(cx, exceptionStack, JS::ErrorReportBuilder::WithSideEffects /* may call the `toString` method if an object is thrown */)) {
     PyErr_SetString(SpiderMonkeyError, "Spidermonkey set an exception, but could not initialize the error report.");


### PR DESCRIPTION
Although not mentioned anywhere in Python 3.12 changelog, the internal representation of the sign bits and number of digits for a Python int has been changed in Python 3.12.

Comparing https://github.com/python/cpython/blob/v3.12.0b1/Include/cpython/longintrepr.h#L82-L90 and https://github.com/python/cpython/blob/v3.11.3/Include/cpython/longintrepr.h#L82-L85, `PyLongObject` is no longer an extension of the `PyVarObject` struct, thus the sign bit is no longer the sign of `obj->ob_size`.

Instead, this info is stored in `obj->long_value.lv_tag`, using lower 2 bits for sign, 1 bit reserved, and the remaining for the digit count.
https://github.com/python/cpython/blob/v3.12.0b1/Include/internal/pycore_long.h#L111-L115