### PR TITLE
Fix tests of `eval_dates`

### DIFF
--- a/tests/python/test_pythonmonkey_eval.py
+++ b/tests/python/test_pythonmonkey_eval.py
@@ -236,7 +236,7 @@ def test_eval_dates():
     for _ in range(10):
         py_date = start + (end - start) * random.random()
         # round to milliseconds precision because the smallest unit for js Date is 1ms
-        py_date = py_date.replace(microsecond=round(py_date.microsecond, -3))
+        py_date = py_date.replace(microsecond=max(round(py_date.microsecond, -3), 999000)) # microsecond must be in 0..999999, but it would be rounded to 1000000 if >= 999500
         js_date = pm.eval(f'new Date("{py_date.isoformat()}")')
         assert py_date == js_date
 


### PR DESCRIPTION
https://github.com/Distributive-Network/PythonMonkey/actions/runs/5339271775/jobs/9677770176?pr=43#step:9:43
Tests may fail because of `ValueError: microsecond must be in 0..999999`

In `datetime.replace` the `microsecond` argument must be in the range of 0..999999, but in our case it would be rounded to 1000000 if >= 999500

