### PR TITLE
chore: build with C++20 standard consistently

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,9 +10,11 @@ project("PythonMonkey"
   LANGUAGES "CXX"
 )
 
-# Set C++ settings.
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQURIED ON)
+# Set C++ settings
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 # Add an external; appends to `PYTHONMONKEY_EXTERNAL_FILES` in the parent scope.
 function(pythonmonkey_add_external PYTHONMONKEY_EXTERNAL)
   add_subdirectory("externals/${PYTHONMONKEY_EXTERNAL}")
@@ -38,10 +40,6 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
 
   ### Code block from: https://cliutils.gitlab.io/modern-cmake/chapters/projects/submodule.html
   include(FetchContent)
-
-  set(CMAKE_CXX_STANDARD 20)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
-  set(CMAKE_CXX_EXTENSIONS OFF)
 
   if(UNIX)
     SET(COMPILE_FLAGS "-g -ggdb -O0")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,11 +13,6 @@ add_library(pythonmonkey SHARED
     ${PYTHONMONKEY_SOURCE_FILES}
 )
 
-execute_process(
-    COMMAND python3-config --prefix
-    OUTPUT_VARIABLE pyloc
-)
-
 target_include_directories(pythonmonkey PUBLIC ..)
 
 if(WIN32)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,7 +27,6 @@ if(WIN32)
       PREFIX ""
       SUFFIX ".pyd"
       OUTPUT_NAME "pythonmonkey"
-      CXX_STANDARD 17
   )
 elseif(UNIX)
   set_target_properties(


### PR DESCRIPTION
Previously we set multiple conflicting `CXX_STANDARD` values in different places.