### PR TITLE
Publish nightly builds as a very basic Python package repository to GitHub Pages

### DIFF
--- a/.github/workflows/test-and-publish.yaml
+++ b/.github/workflows/test-and-publish.yaml
@@ -134,3 +134,44 @@ jobs:
           poetry publish \
             --no-interaction --skip-existing \
             --username __token__ --password ${{ secrets.PYPI_API_TOKEN }}
+  publish-nightly:
+    # Implement a very basic Python package repository (https://peps.python.org/pep-0503/)
+    # and deploy the static files to GitHub Pages
+    needs: [build-and-test, sdist]
+    runs-on: ubuntu-20.04
+    if: ${{ success() || failure() }} # allow tests failure for nightly builds
+    permissions: # grant GITHUB_TOKEN the permissions required to make a Pages deployment
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      # don't checkout
+      - name: Download wheels built
+        uses: actions/download-artifact@v3
+        with:
+          name: wheel-${{ github.run_id }}-${{ github.sha }}
+          path: ./pythonmonkey/ # write to the repository project path 
+      - name: Generate index page for the project
+        run: |
+          cd ./pythonmonkey/
+          html="<html><head><title>PythonMonkey Nightly Builds</title></head><body>"
+          for file in ./*; do # generate <a> tags for each file
+            html+="<a href=\"$file\">$file</a><br/>"
+          done
+          html+="</body></html>"
+          echo "$html" > ./index.html
+      - name: Generate repository root page
+        run: |
+          html="<html><head><title>PythonMonkey Nightly Builds</title></head><body>"
+          html+="<a href="pythonmonkey/">pythonmonkey</a>"
+          html+="</body></html>"
+          echo "$html" > ./index.html
+      - run: ls -alR ./
+      - uses: actions/upload-pages-artifact@v1
+        with:
+          path: ./
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/.github/workflows/test-and-publish.yaml
+++ b/.github/workflows/test-and-publish.yaml
@@ -139,7 +139,7 @@ jobs:
     # and deploy the static files to GitHub Pages
     needs: [build-and-test, sdist]
     runs-on: ubuntu-20.04
-    if: ${{ success() || failure() }} # allow tests failure for nightly builds
+    if: ${{ (success() || failure()) && github.ref_name == 'main' }} # publish nightly builds regardless of tests failure
     permissions: # grant GITHUB_TOKEN the permissions required to make a Pages deployment
       pages: write
       id-token: write

--- a/.github/workflows/test-and-publish.yaml
+++ b/.github/workflows/test-and-publish.yaml
@@ -167,7 +167,7 @@ jobs:
           html="<html><head><title>PythonMonkey Nightly Builds</title></head><body>"
           html+="<h1>PythonMonkey Nightly Builds</h1>"
           html+="<p>To install nightly builds, run</p>"
-          html+="<pre>pip install -i https://nightly.pythonmonkey.io/ pythonmonkey</pre>"
+          html+="<pre>pip install -i https://nightly.pythonmonkey.io/ --pre pythonmonkey</pre>"
           html+="<h3>Browse files:</h3>"
           html+="<a href="pythonmonkey/">pythonmonkey</a>"
           html+="</body></html>"

--- a/.github/workflows/test-and-publish.yaml
+++ b/.github/workflows/test-and-publish.yaml
@@ -165,10 +165,13 @@ jobs:
       - name: Generate repository root page
         run: |
           html="<html><head><title>PythonMonkey Nightly Builds</title></head><body>"
+          html+="<h1>PythonMonkey Nightly Builds</h1>"
+          html+="<p>To install nightly builds, run</p>"
+          html+="<pre>pip install -i https://distributive-network.github.io/PythonMonkey/ pythonmonkey</pre>"
+          html+="<h3>Browse files:</h3>"
           html+="<a href="pythonmonkey/">pythonmonkey</a>"
           html+="</body></html>"
           echo "$html" > ./index.html
-      - run: ls -alR ./
       - uses: actions/upload-pages-artifact@v1
         with:
           path: ./

--- a/.github/workflows/test-and-publish.yaml
+++ b/.github/workflows/test-and-publish.yaml
@@ -167,7 +167,7 @@ jobs:
           html="<html><head><title>PythonMonkey Nightly Builds</title></head><body>"
           html+="<h1>PythonMonkey Nightly Builds</h1>"
           html+="<p>To install nightly builds, run</p>"
-          html+="<pre>pip install -i https://distributive-network.github.io/PythonMonkey/ pythonmonkey</pre>"
+          html+="<pre>pip install -i https://nightly.pythonmonkey.io/ pythonmonkey</pre>"
           html+="<h3>Browse files:</h3>"
           html+="<a href="pythonmonkey/">pythonmonkey</a>"
           html+="</body></html>"

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ $ pip install pythonmonkey
 ### Install the [nightly build](https://nightly.pythonmonkey.io/)
 
 ```bash
-$ pip install -i https://nightly.pythonmonkey.io/ pythonmonkey
+$ pip install -i https://nightly.pythonmonkey.io/ --pre pythonmonkey
 ```
 
 ### Use local version

--- a/README.md
+++ b/README.md
@@ -71,10 +71,10 @@ this package to execute our complex `dcp-client` library, which is written in JS
 $ pip install pythonmonkey
 ```
 
-### Install the [nightly build](https://distributive-network.github.io/PythonMonkey/)
+### Install the [nightly build](https://nightly.pythonmonkey.io/)
 
 ```bash
-$ pip install -i https://distributive-network.github.io/PythonMonkey/ pythonmonkey
+$ pip install -i https://nightly.pythonmonkey.io/ pythonmonkey
 ```
 
 ### Use local version

--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ this package to execute our complex `dcp-client` library, which is written in JS
 $ pip install pythonmonkey
 ```
 
+### Install the [nightly build](https://distributive-network.github.io/PythonMonkey/)
+
+```bash
+$ pip install -i https://distributive-network.github.io/PythonMonkey/ pythonmonkey
+```
+
 ### Use local version
 
 `pythonmonkey` is available in the poetry virtualenv once you compiled the project using poetry.


### PR DESCRIPTION
Implemented based on https://peps.python.org/pep-0503/

People can install nightly builds using 
```sh
pip install -i https://nightly.pythonmonkey.io/ pythonmonkey
```