### PR TITLE
chore: set the minimum cmake version to 3.25

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright (c) 2022 Distributive Inc. All Rights Reserved.
 
-cmake_minimum_required(VERSION 3.4...3.18) # Set minimum cmake version
+cmake_minimum_required(VERSION 3.25) # Set minimum cmake version
 
 project("PythonMonkey"
   DESCRIPTION "A tool for Javascript-Python interoperability."


### PR DESCRIPTION
The `LINUX` variable was added in cmake 3.25, and the `UNIX` variable is broad that also includes macOS
> `UNIX`: is TRUE on all UNIX-like OS's, including Apple OS X and _CygWin_