### PR TITLE
Fix numpy dep for Python 3.12

### DIFF
--- a/.github/workflows/test-and-publish.yaml
+++ b/.github/workflows/test-and-publish.yaml
@@ -111,7 +111,7 @@ jobs:
             sudo apt-get update -y
             sudo apt-get install -y cmake doxygen graphviz llvm
           elif [[ "$OSTYPE" == "darwin"* ]]; then # macOS
-            brew update
+            brew update || true # allow failure
             brew install cmake doxygen graphviz pkg-config wget coreutils # `coreutils` installs the `realpath` command
           fi
           echo "Installing python deps"

--- a/poetry.lock
+++ b/poetry.lock
@@ -38,39 +38,39 @@ files = [
 
 [[package]]
 name = "numpy"
-version = "1.24.3"
+version = "1.24.4"
 description = "Fundamental package for array computing in Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "numpy-1.24.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:3c1104d3c036fb81ab923f507536daedc718d0ad5a8707c6061cdfd6d184e570"},
-    {file = "numpy-1.24.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:202de8f38fc4a45a3eea4b63e2f376e5f2dc64ef0fa692838e31a808520efaf7"},
-    {file = "numpy-1.24.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8535303847b89aa6b0f00aa1dc62867b5a32923e4d1681a35b5eef2d9591a463"},
-    {file = "numpy-1.24.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2d926b52ba1367f9acb76b0df6ed21f0b16a1ad87c6720a1121674e5cf63e2b6"},
-    {file = "numpy-1.24.3-cp310-cp310-win32.whl", hash = "sha256:f21c442fdd2805e91799fbe044a7b999b8571bb0ab0f7850d0cb9641a687092b"},
-    {file = "numpy-1.24.3-cp310-cp310-win_amd64.whl", hash = "sha256:ab5f23af8c16022663a652d3b25dcdc272ac3f83c3af4c02eb8b824e6b3ab9d7"},
-    {file = "numpy-1.24.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:9a7721ec204d3a237225db3e194c25268faf92e19338a35f3a224469cb6039a3"},
-    {file = "numpy-1.24.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d6cc757de514c00b24ae8cf5c876af2a7c3df189028d68c0cb4eaa9cd5afc2bf"},
-    {file = "numpy-1.24.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:76e3f4e85fc5d4fd311f6e9b794d0c00e7002ec122be271f2019d63376f1d385"},
-    {file = "numpy-1.24.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a1d3c026f57ceaad42f8231305d4653d5f05dc6332a730ae5c0bea3513de0950"},
-    {file = "numpy-1.24.3-cp311-cp311-win32.whl", hash = "sha256:c91c4afd8abc3908e00a44b2672718905b8611503f7ff87390cc0ac3423fb096"},
-    {file = "numpy-1.24.3-cp311-cp311-win_amd64.whl", hash = "sha256:5342cf6aad47943286afa6f1609cad9b4266a05e7f2ec408e2cf7aea7ff69d80"},
-    {file = "numpy-1.24.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:7776ea65423ca6a15255ba1872d82d207bd1e09f6d0894ee4a64678dd2204078"},
-    {file = "numpy-1.24.3-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:ae8d0be48d1b6ed82588934aaaa179875e7dc4f3d84da18d7eae6eb3f06c242c"},
-    {file = "numpy-1.24.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ecde0f8adef7dfdec993fd54b0f78183051b6580f606111a6d789cd14c61ea0c"},
-    {file = "numpy-1.24.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4749e053a29364d3452c034827102ee100986903263e89884922ef01a0a6fd2f"},
-    {file = "numpy-1.24.3-cp38-cp38-win32.whl", hash = "sha256:d933fabd8f6a319e8530d0de4fcc2e6a61917e0b0c271fded460032db42a0fe4"},
-    {file = "numpy-1.24.3-cp38-cp38-win_amd64.whl", hash = "sha256:56e48aec79ae238f6e4395886b5eaed058abb7231fb3361ddd7bfdf4eed54289"},
-    {file = "numpy-1.24.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:4719d5aefb5189f50887773699eaf94e7d1e02bf36c1a9d353d9f46703758ca4"},
-    {file = "numpy-1.24.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:0ec87a7084caa559c36e0a2309e4ecb1baa03b687201d0a847c8b0ed476a7187"},
-    {file = "numpy-1.24.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ea8282b9bcfe2b5e7d491d0bf7f3e2da29700cec05b49e64d6246923329f2b02"},
-    {file = "numpy-1.24.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:210461d87fb02a84ef243cac5e814aad2b7f4be953b32cb53327bb49fd77fbb4"},
-    {file = "numpy-1.24.3-cp39-cp39-win32.whl", hash = "sha256:784c6da1a07818491b0ffd63c6bbe5a33deaa0e25a20e1b3ea20cf0e43f8046c"},
-    {file = "numpy-1.24.3-cp39-cp39-win_amd64.whl", hash = "sha256:d5036197ecae68d7f491fcdb4df90082b0d4960ca6599ba2659957aafced7c17"},
-    {file = "numpy-1.24.3-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:352ee00c7f8387b44d19f4cada524586f07379c0d49270f87233983bc5087ca0"},
-    {file = "numpy-1.24.3-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1a7d6acc2e7524c9955e5c903160aa4ea083736fde7e91276b0e5d98e6332812"},
-    {file = "numpy-1.24.3-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:35400e6a8d102fd07c71ed7dcadd9eb62ee9a6e84ec159bd48c28235bbb0f8e4"},
-    {file = "numpy-1.24.3.tar.gz", hash = "sha256:ab344f1bf21f140adab8e47fdbc7c35a477dc01408791f8ba00d018dd0bc5155"},
+    {file = "numpy-1.24.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c0bfb52d2169d58c1cdb8cc1f16989101639b34c7d3ce60ed70b19c63eba0b64"},
+    {file = "numpy-1.24.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ed094d4f0c177b1b8e7aa9cba7d6ceed51c0e569a5318ac0ca9a090680a6a1b1"},
+    {file = "numpy-1.24.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:79fc682a374c4a8ed08b331bef9c5f582585d1048fa6d80bc6c35bc384eee9b4"},
+    {file = "numpy-1.24.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7ffe43c74893dbf38c2b0a1f5428760a1a9c98285553c89e12d70a96a7f3a4d6"},
+    {file = "numpy-1.24.4-cp310-cp310-win32.whl", hash = "sha256:4c21decb6ea94057331e111a5bed9a79d335658c27ce2adb580fb4d54f2ad9bc"},
+    {file = "numpy-1.24.4-cp310-cp310-win_amd64.whl", hash = "sha256:b4bea75e47d9586d31e892a7401f76e909712a0fd510f58f5337bea9572c571e"},
+    {file = "numpy-1.24.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f136bab9c2cfd8da131132c2cf6cc27331dd6fae65f95f69dcd4ae3c3639c810"},
+    {file = "numpy-1.24.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e2926dac25b313635e4d6cf4dc4e51c8c0ebfed60b801c799ffc4c32bf3d1254"},
+    {file = "numpy-1.24.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:222e40d0e2548690405b0b3c7b21d1169117391c2e82c378467ef9ab4c8f0da7"},
+    {file = "numpy-1.24.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7215847ce88a85ce39baf9e89070cb860c98fdddacbaa6c0da3ffb31b3350bd5"},
+    {file = "numpy-1.24.4-cp311-cp311-win32.whl", hash = "sha256:4979217d7de511a8d57f4b4b5b2b965f707768440c17cb70fbf254c4b225238d"},
+    {file = "numpy-1.24.4-cp311-cp311-win_amd64.whl", hash = "sha256:b7b1fc9864d7d39e28f41d089bfd6353cb5f27ecd9905348c24187a768c79694"},
+    {file = "numpy-1.24.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:1452241c290f3e2a312c137a9999cdbf63f78864d63c79039bda65ee86943f61"},
+    {file = "numpy-1.24.4-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:04640dab83f7c6c85abf9cd729c5b65f1ebd0ccf9de90b270cd61935eef0197f"},
+    {file = "numpy-1.24.4-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a5425b114831d1e77e4b5d812b69d11d962e104095a5b9c3b641a218abcc050e"},
+    {file = "numpy-1.24.4-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dd80e219fd4c71fc3699fc1dadac5dcf4fd882bfc6f7ec53d30fa197b8ee22dc"},
+    {file = "numpy-1.24.4-cp38-cp38-win32.whl", hash = "sha256:4602244f345453db537be5314d3983dbf5834a9701b7723ec28923e2889e0bb2"},
+    {file = "numpy-1.24.4-cp38-cp38-win_amd64.whl", hash = "sha256:692f2e0f55794943c5bfff12b3f56f99af76f902fc47487bdfe97856de51a706"},
+    {file = "numpy-1.24.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:2541312fbf09977f3b3ad449c4e5f4bb55d0dbf79226d7724211acc905049400"},
+    {file = "numpy-1.24.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:9667575fb6d13c95f1b36aca12c5ee3356bf001b714fc354eb5465ce1609e62f"},
+    {file = "numpy-1.24.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f3a86ed21e4f87050382c7bc96571755193c4c1392490744ac73d660e8f564a9"},
+    {file = "numpy-1.24.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d11efb4dbecbdf22508d55e48d9c8384db795e1b7b51ea735289ff96613ff74d"},
+    {file = "numpy-1.24.4-cp39-cp39-win32.whl", hash = "sha256:6620c0acd41dbcb368610bb2f4d83145674040025e5536954782467100aa8835"},
+    {file = "numpy-1.24.4-cp39-cp39-win_amd64.whl", hash = "sha256:befe2bf740fd8373cf56149a5c23a0f601e82869598d41f8e188a0e9869926f8"},
+    {file = "numpy-1.24.4-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:31f13e25b4e304632a4619d0e0777662c2ffea99fcae2029556b17d8ff958aef"},
+    {file = "numpy-1.24.4-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:95f7ac6540e95bc440ad77f56e520da5bf877f87dca58bd095288dce8940532a"},
+    {file = "numpy-1.24.4-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:e98f220aa76ca2a977fe435f5b04d7b3470c0a2e6312907b37ba6068f26787f2"},
+    {file = "numpy-1.24.4.tar.gz", hash = "sha256:80f5e3a4e498641401868df4208b74581206afbee7cf7b8329daae82676d9463"},
 ]
 
 [[package]]
@@ -80,35 +80,35 @@ description = "Fundamental package for array computing in Python"
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "numpy-2.0.0.dev0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:478dfd375d08209aacb7eff4236b6365c48a08caf8f64fe12a276be603ce31a0"},
+    {file = "numpy-2.0.0.dev0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d9ee815dd72c00bf2b842f00eca5174b65e8357467561ce3a3711ea666217ebd"},
     {file = "numpy-2.0.0.dev0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9b07c082a32afacf20c72f3e7cfb84b97ac01dd7eabc11a6f339e6d0859cc73c"},
     {file = "numpy-2.0.0.dev0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9e5df60daeb76746476a02d85907a2e65661ad0180a5516dd04d6efb77202bbc"},
-    {file = "numpy-2.0.0.dev0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ac913b8701bd4f10ba97a816343723c0d53ec4bf0d087b7cd99368b58a68b22a"},
-    {file = "numpy-2.0.0.dev0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:5d97281cb7e9c477ab77d06cc89d48c031d036b7663b838c8346af6546cee1ac"},
-    {file = "numpy-2.0.0.dev0-cp310-cp310-win_amd64.whl", hash = "sha256:f8ba76f32276f63d128df555f7ea6cfbdb2ef42a80f6c0b545ac8c85e4e0a5e3"},
-    {file = "numpy-2.0.0.dev0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a8f6745f783f8635bf7101612cbccd9537235e3a437558c04fbac1014f98d780"},
+    {file = "numpy-2.0.0.dev0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1f7f7b2e458ca033a8c28718f57bf2c6bc72b6e091d7a98b4ed0926cce475d7e"},
+    {file = "numpy-2.0.0.dev0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:26fef32b250ebbbabd176d4c6f7f74b35461cd035cb7d7575141c42e96a162cb"},
+    {file = "numpy-2.0.0.dev0-cp310-cp310-win_amd64.whl", hash = "sha256:95f6254daf1f067759660cfe98dc80615e68c6811130cc6edb4650be82eb3a94"},
+    {file = "numpy-2.0.0.dev0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:e5bb824a54c6ecedd262cedeaf148f0a20d18352bf01648d6495fad6bf90fad5"},
     {file = "numpy-2.0.0.dev0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7e2edb7eb45409a3822e8d5e5a4e84ff797f90a7ba79192f33f0c8c7fc20db29"},
     {file = "numpy-2.0.0.dev0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9a2871d629cd39048c3e75e29f80e5166dafd5eb08f0ef7292c10fd44523a376"},
-    {file = "numpy-2.0.0.dev0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c9a7a133cc47dd7722903fca2a0ed6babb85ece11812b67a5dc35b4b12f6066d"},
-    {file = "numpy-2.0.0.dev0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:6f2e93b0b1fce6fc837490e57a4df2a6be1d7f265d021373fc06b6b50c14636d"},
-    {file = "numpy-2.0.0.dev0-cp311-cp311-win_amd64.whl", hash = "sha256:9d87be292337724ca2930a090e851dbb9a790633074de192bae3b431164bb769"},
-    {file = "numpy-2.0.0.dev0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:f609d39574b664c7966db689a128323bf3d746508ce5a4f52e467d8c5f58832c"},
+    {file = "numpy-2.0.0.dev0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4d0331bc691ffbbbee176808bc3383abe9f99034d7aaba8cf2ccba62e60064c1"},
+    {file = "numpy-2.0.0.dev0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:3eaa3ad03c472e6d0d2d7a2c51cc8d013a0ff02219ef04c1a699da534587d924"},
+    {file = "numpy-2.0.0.dev0-cp311-cp311-win_amd64.whl", hash = "sha256:b67f2d97cd5cb4839cd3c881d31c639b8ee99c3773fbf39440a086eaef6c08f0"},
+    {file = "numpy-2.0.0.dev0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:4a5c13f25048bb00c6241e6f274e7882c446c9810f4897f86a79fb20a10dca57"},
     {file = "numpy-2.0.0.dev0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7d5d890b2054ce93e7930f5b77fa45023a805de9670715fad2f874beabaf3e90"},
     {file = "numpy-2.0.0.dev0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0b489b60da67d6e97c233982156eb6ee512a091d48868aa6e72ab5cd8eeaf629"},
-    {file = "numpy-2.0.0.dev0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c39f0903ca21a06bb729c60a2fad967d1652e4e3601b4ba2036035497a669aea"},
-    {file = "numpy-2.0.0.dev0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:cefb27e59e0c3c8842f25b84cb950cc2de7c133ae4aaed3a725d39f0ce990d0b"},
-    {file = "numpy-2.0.0.dev0-cp312-cp312-win_amd64.whl", hash = "sha256:4481711d013d310a7f440265594677a9d333cdfeebd22850446d66df631388f4"},
-    {file = "numpy-2.0.0.dev0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:742746e48a87c568c712fcc05860e99f4b7b0c7274dedd9abf3f26746a6ba388"},
+    {file = "numpy-2.0.0.dev0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8a9b6d9543618a0b4aba4a29b12853042adccfc416809398121a143751c0da14"},
+    {file = "numpy-2.0.0.dev0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:1741a0b350a21d5aae34105760b80b1fb597082e8a8dc9c2d903a2244e0d9dfb"},
+    {file = "numpy-2.0.0.dev0-cp312-cp312-win_amd64.whl", hash = "sha256:4cb78b51a2c0900e827e32b86bbf2d35e5da77034d13583eb613baef13733e5b"},
+    {file = "numpy-2.0.0.dev0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d054fc187f28c68896c3d7de1120287fa3e26f905825686ef1ab99089060ef14"},
     {file = "numpy-2.0.0.dev0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:45b6e9e8a641d9ae72112bfa9abac37a0a135d522e6fb6be56b8ca10957fc737"},
     {file = "numpy-2.0.0.dev0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:022fa4ee86825096ce654cf90bd1ec57538c5a7627b28bc30ce2a83b00580aa6"},
-    {file = "numpy-2.0.0.dev0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:60fdddc40f8c0aa31a37a8a76ddac76d6b36e1a80be35903e23dd5e3b1d263de"},
-    {file = "numpy-2.0.0.dev0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:1fd71edeedbf239eea5d77d15d7036f1e58cb5eebbcbd4fadf7e1dbe276203df"},
-    {file = "numpy-2.0.0.dev0-cp39-cp39-win_amd64.whl", hash = "sha256:115c40c23a67e9a0196cc343ddffcac353bdea702c497e865e75236d59b25872"},
+    {file = "numpy-2.0.0.dev0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:37565dd074af4d359ace61c2c65ab6684763f2e7549c1dc9cd5a096c0be6b8e0"},
+    {file = "numpy-2.0.0.dev0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:7504b42d17ed110b48363f899c1a1babc8fb8249743c9cfb85e57dbadbce02e0"},
+    {file = "numpy-2.0.0.dev0-cp39-cp39-win_amd64.whl", hash = "sha256:e34d5b3b969a13355b9ee1d55e98d4264119815c19928d011b353cb87f548cc1"},
 ]
 
 [package.source]
 type = "legacy"
-url = "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple"
+url = "https://pypi.anaconda.org/nightly/simple"
 reference = "anaconda-nightly"
 
 [[package]]
@@ -135,13 +135,13 @@ files = [
 
 [[package]]
 name = "pluggy"
-version = "1.0.0"
+version = "1.2.0"
 description = "plugin and hook calling mechanisms for python"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 files = [
-    {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
-    {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
+    {file = "pluggy-1.2.0-py3-none-any.whl", hash = "sha256:c2fd55a7d7a3863cba1a013e4e2414658b1d07b6bc57b3919e0c63c9abb99849"},
+    {file = "pluggy-1.2.0.tar.gz", hash = "sha256:d12f0c4b579b15f5e054301bb226ee85eeeba08ffec228092f8defbaa3a4c4b3"},
 ]
 
 [package.extras]
@@ -150,13 +150,13 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "pytest"
-version = "7.3.2"
+version = "7.4.0"
 description = "pytest: simple powerful testing with Python"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pytest-7.3.2-py3-none-any.whl", hash = "sha256:cdcbd012c9312258922f8cd3f1b62a6580fdced17db6014896053d47cddf9295"},
-    {file = "pytest-7.3.2.tar.gz", hash = "sha256:ee990a3cc55ba808b80795a79944756f315c67c12b56abd3ac993a7b8c17030b"},
+    {file = "pytest-7.4.0-py3-none-any.whl", hash = "sha256:78bf16451a2eb8c7a2ea98e32dc119fd2aa758f1d5d66dbf0a59d69a3969df32"},
+    {file = "pytest-7.4.0.tar.gz", hash = "sha256:b4bf8c45bd59934ed84001ad51e11b4ee40d40a1229d2c79f9c592b0a3f6bd8a"},
 ]
 
 [package.dependencies]
@@ -184,4 +184,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "aa27d5c42852d150b108948825e0ad7892e7456a9f80600151117abd33bc9db3"
+content-hash = "480d45c78851c132fa65e5ed7618847ed666bbf7d74abf693c1ef5b60dbf27f2"

--- a/poetry.lock
+++ b/poetry.lock
@@ -108,8 +108,8 @@ files = [
 
 [package.source]
 type = "legacy"
-url = "https://pypi.anaconda.org/nightly/simple"
-reference = "anaconda-nightly"
+url = "https://pypi.anaconda.org/pythonmonkey/simple"
+reference = "anaconda"
 
 [[package]]
 name = "packaging"
@@ -184,4 +184,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "480d45c78851c132fa65e5ed7618847ed666bbf7d74abf693c1ef5b60dbf27f2"
+content-hash = "b6c04db7deac0a2e9850f6ea1e00e2a00c7e612dfc765171864ca906386e2878"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,16 +49,16 @@ generate-setup-file = false
 pytest = "^7.3.1"
 pip = "^23.1.2"
 numpy = [
-  # numpy hasn't released for Python 3.12 yet on PyPI, but Anaconda nightly build has it.
+  # numpy hasn't released for Python 3.12 yet on PyPI
   # TODO: use the PyPI build once the wheels are released for Python 3.12
-  {version = "^2.0.0.dev0", allow-prereleases = true, source = "anaconda-nightly", python = "3.12.*"},
+  {version = "^2.0.0.dev0", allow-prereleases = true, source = "anaconda", python = "3.12.*"},
   {version = "^1.24.3", python = "<3.12"},
 ]
 
 
 [[tool.poetry.source]]
-name = "anaconda-nightly"
-url = "https://pypi.anaconda.org/nightly/simple"
+name = "anaconda"
+url = "https://pypi.anaconda.org/pythonmonkey/simple"
 priority = "explicit"
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ numpy = [
 
 [[tool.poetry.source]]
 name = "anaconda-nightly"
-url = "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple"
+url = "https://pypi.anaconda.org/nightly/simple"
 priority = "explicit"
 
 [build-system]


### PR DESCRIPTION
https://github.com/Distributive-Network/PythonMonkey/actions/runs/5414159268/jobs/9844895604#step:5:238
> Hash for numpy (2.0.0.dev0) from archive numpy-2.0.0.dev0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl not found in known hashes (was: sha256:8a9b6d9543618a0b4aba4a29b12853042adccfc416809398121a143751c0da14)

It seems that the package content has changed for the same version `numpy-2.0.0.dev0`.

We copy the package to our own [`pythonmonkey` namespace on Anaconda](https://anaconda.org/pythonmonkey/numpy) to pin version.