### PR TITLE
Fix: Python modules require can't see `exports['abc'] = xyz`

### DIFF
--- a/python/pythonmonkey/require.py
+++ b/python/pythonmonkey/require.py
@@ -208,10 +208,7 @@ def load(filename: str) -> Dict:
         spec.loader.exec_module(module)
     else:
         module = sys.modules[name]
-    module_exports = {}
-    for key in dir(module):
-        module_exports[key] = getattr(module, key)
-    return module_exports 
+    return module.exports
 globalThis.python.load = load
 
 """


### PR DESCRIPTION
`python.load` should use the `module.exports` dict instead of taking the Pythonic exports