### PR TITLE
chore: upgrade SpiderMonkey to 102.13.0 ESR

### DIFF
--- a/.github/workflows/test-and-publish.yaml
+++ b/.github/workflows/test-and-publish.yaml
@@ -40,7 +40,7 @@ jobs:
         with:
           path: |
             ./_spidermonkey_install/*
-          key: spidermonkey-${{ runner.os }}-${{ runner.arch }}
+          key: spidermonkey102.13-${{ runner.os }}-${{ runner.arch }}
           lookup-only: true # skip download
       - name: Setup Poetry
         if: ${{ steps.cache-spidermonkey.outputs.cache-hit != 'true' }}
@@ -60,7 +60,7 @@ jobs:
         with:
           path: |
             ./_spidermonkey_install/*
-          key: spidermonkey-${{ runner.os }}-${{ runner.arch }}
+          key: spidermonkey102.13-${{ runner.os }}-${{ runner.arch }}
           lookup-only: true # skip download
       - name: Setup Poetry
         if: ${{ steps.cache-spidermonkey.outputs.cache-hit != 'true' }}
@@ -135,7 +135,7 @@ jobs:
         with:
           path: |
             ./_spidermonkey_install/*
-          key: spidermonkey-${{ runner.os }}-${{ runner.arch }}
+          key: spidermonkey102.13-${{ runner.os }}-${{ runner.arch }}
           fail-on-cache-miss: true # SpiderMonkey is expected to be cached in its dedicated job
       - name: Build pminit
         run: |

--- a/setup.sh
+++ b/setup.sh
@@ -27,9 +27,9 @@ poetry self add "poetry-dynamic-versioning[plugin]"
 echo "Done installing dependencies"
 
 echo "Downloading spidermonkey source code"
-wget -c -q https://ftp.mozilla.org/pub/firefox/releases/102.11.0esr/source/firefox-102.11.0esr.source.tar.xz
+wget -c -q https://ftp.mozilla.org/pub/firefox/releases/102.13.0esr/source/firefox-102.13.0esr.source.tar.xz
 mkdir -p firefox-source
-tar xf firefox-102.11.0esr.source.tar.xz -C firefox-source --strip-components=1 # strip the root folder
+tar xf firefox-102.13.0esr.source.tar.xz -C firefox-source --strip-components=1 # strip the root folder
 echo "Done downloading spidermonkey source code"
 
 echo "Building spidermonkey"


### PR DESCRIPTION
We should make sure that https://ubuntu.com/security/notices/USN-6147-1 doesn't affect us before launch.

It was patched in SpiderMonkey 102.12, but we are currently building against SpiderMonkey 102.11.