### PR TITLE
Fix nightly build

### DIFF
--- a/.github/workflows/test-and-publish.yaml
+++ b/.github/workflows/test-and-publish.yaml
@@ -156,7 +156,7 @@ jobs:
           path: ./dist/
       - name: Run Python tests (pytest)
         run: |
-          poetry run python -m pip install --force-reinstall ./dist/*
+          poetry run python -m pip install --force-reinstall --verbose ./dist/*
           poetry run python -m pytest tests/python
   sdist:
     runs-on: ubuntu-20.04

--- a/.github/workflows/test-and-publish.yaml
+++ b/.github/workflows/test-and-publish.yaml
@@ -250,8 +250,8 @@ jobs:
           html+="<p>To install nightly builds, run</p>"
           html+="<pre>pip install -i https://nightly.pythonmonkey.io/ --pre pythonmonkey</pre>"
           html+="<h3>Browse files:</h3>"
-          html+="<a href="pythonmonkey/">pythonmonkey</a>"
-          html+="<a href="pminit/">pminit</a>"
+          html+="<li><a href="pythonmonkey/">pythonmonkey</a></li>"
+          html+="<li><a href="pminit/">pminit</a></li>"
           html+="</body></html>"
           echo "$html" > ./index.html
       - uses: actions/upload-pages-artifact@v1

--- a/.github/workflows/test-and-publish.yaml
+++ b/.github/workflows/test-and-publish.yaml
@@ -248,7 +248,7 @@ jobs:
           html="<html><head><title>PythonMonkey Nightly Builds</title></head><body>"
           html+="<h1>PythonMonkey Nightly Builds</h1>"
           html+="<p>To install nightly builds, run</p>"
-          html+="<pre>pip install -i https://nightly.pythonmonkey.io/ --pre pythonmonkey</pre>"
+          html+="<pre>pip install --extra-index-url https://nightly.pythonmonkey.io/ --pre pythonmonkey</pre>"
           html+="<h3>Browse files:</h3>"
           html+="<li><a href="pythonmonkey/">pythonmonkey</a></li>"
           html+="<li><a href="pminit/">pminit</a></li>"

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ $ pip install pythonmonkey
 ### Install the [nightly build](https://nightly.pythonmonkey.io/)
 
 ```bash
-$ pip install -i https://nightly.pythonmonkey.io/ --pre pythonmonkey
+$ pip install --extra-index-url https://nightly.pythonmonkey.io/ --pre pythonmonkey
 ```
 
 ### Use local version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,5 +63,5 @@ url = "https://pypi.anaconda.org/pythonmonkey/simple"
 priority = "explicit"
 
 [build-system]
-requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning"]
+requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning==0.24.0"]
 build-backend = "poetry_dynamic_versioning.backend"

--- a/python/pminit/pyproject.toml
+++ b/python/pminit/pyproject.toml
@@ -30,6 +30,6 @@ script = "post-install-hook.py"
 generate-setup-file = false 
 
 [build-system]
-requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning"]
+requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning==0.24.0"]
 build-backend = "poetry_dynamic_versioning.backend"
 


### PR DESCRIPTION
* Fix installation of the nightly build 
```console
ERROR: Could not find a version that satisfies the requirement pminit (from pythonmonkey) (from versions: 0.0.1.dev938+aa27f65)
ERROR: No matching distribution found for pminit
```

* Fix installation from [source distribution](https://packaging.python.org/en/latest/specifications/source-distribution-format/)
> add `--no-binary pythonmonkey` flag to pip to not use the wheel package
```bash
ModuleNotFoundError: No module named 'poetry_dynamic_versioning.backend'
```

* Improve https://nightly.pythonmonkey.io/ UI