### PR TITLE
feature(pminit): added pminit cli tool 

### DIFF
--- a/python/pminit/pminit/cli.py
+++ b/python/pminit/pminit/cli.py
@@ -22,7 +22,7 @@ def commandType(value: str):
 def main():
     parser = argparse.ArgumentParser(description="A tool to enable running npm on the correct package.json location")
     parser.add_argument("executable", nargs=1, help="Should be npm.", type=commandType)
-    parser.add_argument("args", nargs="+", help="Args to pass into npm command", type=str)
+    parser.add_argument("args", nargs = argparse.REMAINDER)
     args = parser.parse_args()
   
     pythonmonkey_path= os.path.realpath(
@@ -31,8 +31,8 @@ def main():
             '..',
             'pythonmonkey'
         )
-    ) 
-    
+    )
+
     execute(' '.join( args.executable + args.args ), pythonmonkey_path)
 
     

--- a/python/pminit/pminit/cli.py
+++ b/python/pminit/pminit/cli.py
@@ -11,7 +11,10 @@ def execute(cmd: str, cwd: str):
 
     popen.stdout.close()
     return_code = popen.wait()
-    if return_code:
+    #For some reason npm returns a non zero
+    #exit code when `--help` is used in the commands.
+    #This shouldn't raise an error.
+    if return_code and "--help" not in cmd:
         raise subprocess.CalledProcessError(return_code, cmd)
 
 def commandType(value: str):

--- a/python/pminit/pminit/cli.py
+++ b/python/pminit/pminit/cli.py
@@ -1,0 +1,40 @@
+import os, sys
+import subprocess
+import argparse
+
+def execute(cmd: str, cwd: str):
+    popen = subprocess.Popen(cmd, stdout = subprocess.PIPE, stderr = subprocess.STDOUT,
+        shell = True, text = True, cwd = cwd )
+    for stdout_line in iter(popen.stdout.readline, ""):
+        sys.stdout.write(stdout_line)
+        sys.stdout.flush()
+
+    popen.stdout.close()
+    return_code = popen.wait()
+    if return_code:
+        raise subprocess.CalledProcessError(return_code, cmd)
+
+def commandType(value: str):
+    if value != "npm":
+        raise argparse.ArgumentTypeError("Value must be npm.")
+    return value
+
+def main():
+    parser = argparse.ArgumentParser(description="A tool to enable running npm on the correct package.json location")
+    parser.add_argument("executable", nargs=1, help="Should be npm.", type=commandType)
+    parser.add_argument("args", nargs="+", help="Args to pass into npm command", type=str)
+    args = parser.parse_args()
+  
+    pythonmonkey_path= os.path.realpath(
+        os.path.join(
+            os.path.dirname(__file__),
+            '..',
+            'pythonmonkey'
+        )
+    ) 
+    
+    execute(' '.join( args.executable + args.args ), pythonmonkey_path)
+
+    
+    
+    

--- a/python/pminit/pminit/cli.py
+++ b/python/pminit/pminit/cli.py
@@ -11,10 +11,7 @@ def execute(cmd: str, cwd: str):
 
     popen.stdout.close()
     return_code = popen.wait()
-    #For some reason npm returns a non zero
-    #exit code when `--help` is used in the commands.
-    #This shouldn't raise an error.
-    if return_code and "--help" not in cmd:
+    if return_code:
         raise subprocess.CalledProcessError(return_code, cmd)
 
 def commandType(value: str):

--- a/python/pminit/pyproject.toml
+++ b/python/pminit/pyproject.toml
@@ -27,7 +27,10 @@ bump = true
 
 [tool.poetry.build]
 script = "post-install-hook.py"
-generate-setup-file = false 
+generate-setup-file = false
+
+[tool.poetry.scripts]
+pminit = "pminit.cli:main"
 
 [build-system]
 requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning"]


### PR DESCRIPTION
Added a pminit cli tool that enables developers to modify or change package.json for pythonmonkey and even force reinstallation of the node packages.

After this PR, one will be able to do:
`poetry run pminit npm install`


This feature was asked for by @wesgarland and I think it's a very useful addition.