### PR TITLE
build(setup.sh): add missing pkgs on fresh ubuntu systems

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -9,7 +9,8 @@ CPUS=$(getconf _NPROCESSORS_ONLN 2>/dev/null || getconf NPROCESSORS_ONLN 2>/dev/
 echo "Installing dependencies"
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then # Linux
   sudo apt-get update --yes
-  sudo apt-get install cmake doxygen graphviz llvm g++ pkg-config m4 wget --yes
+  sudo apt-get install --yes cmake doxygen graphviz llvm g++ pkg-config m4 \
+    wget curl python3-distutils python3-dev
 elif [[ "$OSTYPE" == "darwin"* ]]; then # macOS
   brew update || true # allow failure
   brew install cmake doxygen graphviz pkg-config wget coreutils # `coreutils` installs the `realpath` command


### PR DESCRIPTION
In a fresh docker container in `ubuntu:20.04`, `curl` isn't installed by default. After installing `git` and `sudo`, I ran `setup.sh` and ran into "curl: command not found".

Given that `setup.sh` uses `curl` right after `apt` installing other packages on Ubuntu machines, we may as well make sure it's available before using it.

After resolving that, Poetry failed to install due to the python module `distutils` being missing [^1]. Fixing it through installing `python3-distutils` seems to work [^2]!

After troubleshooting OS/machine specific dependency setup issues (e.g., `npm`, latest `cmake`), I had to add `python3-dev` to make `setup.sh` match what the README file mentions in the "Build Instructions" section.

[^1]: https://github.com/pypa/get-pip/issues/124
[^2]: https://github.com/pypa/get-pip/issues/124#issuecomment-904380931