### PR TITLE
Add tests for the ArrayBuffer datatype

### DIFF
--- a/tests/js/js2py/arraybuffer.simple
+++ b/tests/js/js2py/arraybuffer.simple
@@ -1,0 +1,30 @@
+/**
+ * @file        js2py/arraybuffer.simple
+ *              Simple test which shows that sending ArrayBuffers to Python and getting them back into JS
+ *              works as expected. Also tests mutation.
+ * @author      Severn Lortie, severn@distributive.network
+ * @date        July 2023
+ */
+'use strict';
+
+const buffer = new ArrayBuffer(5); // 5 bytes
+const bufferView = new Uint8Array(buffer);
+bufferView[0] = 104;
+bufferView[1] = 101;
+bufferView[2] = 108;
+bufferView[3] = 108;
+bufferView[4] = 111;
+
+python.exec(`
+def mutate(x):
+  x[3] = 55;
+  return x;
+`);
+
+const fn = python.eval('mutate');
+const modifiedBuff = fn(buffer); // Call the function which mutates the buffer
+
+// Check that both were updated
+for (let i = 0; i < bufferView.length; i++) 
+  if (modifiedBuff[i] !== bufferView[i]) throw new Error('The buffer was not changed, or not returned correctly.');
+

--- a/tests/js/py2js/arraybuffer.simple
+++ b/tests/js/py2js/arraybuffer.simple
@@ -1,0 +1,25 @@
+/**
+ * @file        py2js/arraybuffer.simple
+ *              Simple test which shows that sending Buffers from python to JavaScript and mutating
+ *              them works
+ * @author      Severn Lortie, severn@distributive.network
+ * @date        July 2023
+ */
+'use strict';
+
+python.exec(`
+x = bytearray([ 104, 101, 108, 108, 111 ])
+`);
+
+const pythonBuff = python.eval('x');
+
+// Mutate the buffer
+pythonBuff[3] = 55;
+
+// Now pass back to python
+const newPythonBuff = python.eval('x');
+
+// Check that both were updated
+for (let i = 0; i < pythonBuff.length; i++) 
+  if (pythonBuff[i] !== newPythonBuff[i]) throw new Error('The buffer was not changed, or not returned correctly.');
+


### PR DESCRIPTION
Add two tests to check the interoperability of the ArrayBuffer datatype. These tests check that the ArrayBuffer can be copied to python, mutated, and read back from JS. They also test that a python "Buffer" (bytearray) can be read in JS, mutated, and read back. 