### PR TITLE
Testing: add tests for passing promises between JS and Python

### DIFF
--- a/tests/js/js2py/promise-await-in-python.simple.failing
+++ b/tests/js/js2py/promise-await-in-python.simple.failing
@@ -1,0 +1,33 @@
+/**
+ * @file        js2py/promise-await-in-python.simple
+ *              Simple test to await a javascript promise as a python awaitable, resolving with the correct value.
+ * @author      Ryan Saweczko ryansaweczko@distributive.network
+ * @date        July 2023
+ */
+'use strict';
+
+var resolve, reject;
+var valToResolve = 1;
+const examplePromise = new Promise((res, rej) => {resolve = res, reject = rej});
+
+const pythonCode = `
+import asyncio
+
+async def awaitPromise(promise):
+  ret = await promise
+  return ret
+`;
+
+python.exec(pythonCode);
+const pythonFunction = python.eval("awaitPromise")
+
+async function test()
+{
+  const backValue = await pythonFunction(examplePromise);
+  if (backValue !== 1)
+    throw new Error(`Received value ${backValue} instead of ${valToResolve} from awaiting a JS promise in python`)
+}
+test()
+
+resolve(valToResolve);
+

--- a/tests/js/js2py/promise.simple.failing
+++ b/tests/js/js2py/promise.simple.failing
@@ -1,0 +1,25 @@
+/**
+ * @file        js2py/promise.simple
+ *              Simple test which shows that creating a promise in javascript and sending it to Python and getting it back into JS
+ *              works as expected - able to resolve the promise sent back.
+ * @author      Ryan Saweczko ryansaweczko@distributive.network
+ * @date        July 2023
+ */
+'use strict';
+
+
+var resolve, reject;
+const examplePromise = new Promise((res, rej) => {resolve = res, reject = rej});
+
+const pythonCode = `lambda x: x`;
+
+const pythonLambda = python.eval(pythonCode);
+const outPromise = pythonLambda(examplePromise);
+
+outPromise.then(() => {
+  console.log("able to resolve promise after going through python");
+  python.exit();
+});
+
+resolve();
+

--- a/tests/js/py2js/promise.simple.failing
+++ b/tests/js/py2js/promise.simple.failing
@@ -1,0 +1,30 @@
+/**
+ * @file        py2js/promise.simple
+ *              Simple test which shows that sending Python awaitable to JS appears as a JS promise
+ * @author      Ryan Saweczko ryansaweczko@distributive.network
+ * @date        July 2023
+ */
+'use strict';
+
+const pythonCode = python.exec(`
+import asyncio
+
+async def nested():
+    return 42
+
+async def main():
+  global asyncio
+  global nested
+  task = asyncio.create_task(nested())
+  return task
+`);
+const task = python.eval('asyncio.run(main())');
+
+if (task instanceof Promise)
+{
+  console.log("Return was a promise");
+}
+else
+{
+  throw new Error(`Received a non-promise in JS from a python awaitable. Type ${typeof(task)}`);
+}


### PR DESCRIPTION
Implement testing for converting a JS Promise to a Python awaitable. Currently this functionality doesn't exist, resulting in most tests seg faulting, or running into other errors. 