### PR TITLE
Add tests for passing dates between JS and Python

### DIFF
--- a/tests/js/js2py/datetime.simple.failing
+++ b/tests/js/js2py/datetime.simple.failing
@@ -1,0 +1,21 @@
+/**
+ * @file        js2py/datetime.simple.failing
+ *              Simple test which shows that sending Dates to Python and getting them back into JS
+ *              works as expected
+ * 
+ * @author      Elijah Deluzio, elijah@distributive.network
+ * @date        July 2023
+ */
+'use strict'
+
+const jsDate = new Date(1111, 2 , 3);
+const throughPython = python.eval('(lambda x: x)');
+const pyDate = throughPython(jsDate);
+
+if (jsDate.getTime() !== pyDate.getTime())
+{
+  console.error('expected', jsDate.getTime(), 'but got', pyDate.getTime());
+  throw new Error('test failed');
+}
+
+console.log('pass -', pyDate);

--- a/tests/js/js2py/datetime.simple.failing
+++ b/tests/js/js2py/datetime.simple.failing
@@ -8,13 +8,32 @@
  */
 'use strict'
 
-const jsDate = new Date(1111, 2 , 3);
 const throughPython = python.eval('(lambda x: x)');
-const pyDate = throughPython(jsDate);
+var expectedJsTimestamp;
+var jsDate;
+var pyDate;
 
-if (jsDate.getTime() !== pyDate.getTime())
+// Test 1: Date from timestamp of 0 (1970 - 01 - 01), timestamp = 0
+jsDate = new Date(Date.UTC(1970, 0, 1, 0, 0, 0));
+expectedJsTimestamp = jsDate.getTime();
+pyDate = throughPython(jsDate);
+
+if (expectedJsTimestamp !== pyDate.getTime())
 {
-  console.error('expected', jsDate.getTime(), 'but got', pyDate.getTime());
+  console.error('expected', expectedJsTimestamp, 'but got', pyDate.getTime());
+  throw new Error('test failed');
+}
+
+console.log('pass -', pyDate);
+
+// Test 2: Date from 21st century (2222 - 02 - 03), timestamp = 7955193600000
+jsDate = new Date(Date.UTC(2222, 1, 3, 0, 0, 0));
+expectedJsTimestamp = jsDate.getTime();
+pyDate = throughPython(jsDate);
+
+if (expectedJsTimestamp !== pyDate.getTime())
+{
+  console.error('expected', expectedJsTimestamp, 'but got', pyDate.getTime());
   throw new Error('test failed');
 }
 

--- a/tests/js/py2js/datetime.simple.failing
+++ b/tests/js/py2js/datetime.simple.failing
@@ -8,15 +8,36 @@
  */
 'use strict'
 
-python.exec(`import datetime`);
-const pyDate = python.eval(`datetime.datetime(1111, 2, 3)`);
-const jsDateExpected = new Date(1111, 2, 3);
 const throughJS = x => x;
-const jsDate = throughJS(pyDate);
+var expectedJsTimestamp;
+var jsDate;
+var pyDate;
 
-if (jsDate.getTime() !== jsDateExpected.getTime())
+// Test 1: Date from timestamp of 0 (1970 - 01 - 01), timestamp = 0
+expectedJsTimestamp = 0;
+python.exec(`from datetime import timezone`)
+python.exec(`import datetime`);
+pyDate = python.eval(`datetime.datetime.fromtimestamp(${expectedJsTimestamp}, tz=timezone.utc)`);
+jsDate = throughJS(pyDate);
+
+if (jsDate.getTime() !== expectedJsTimestamp)
 {
-  console.error('expected', jsDate.getTime(), 'but got', pyDate.getTime());
+  console.error('expected', expectedJsTimestamp, 'but got', jsDate.getTime());
+  throw new Error('test failed');
+}
+
+console.log('pass -', jsDate);
+
+// Test 2: Date from 21st century (2222 - 02 - 03), timestamp = 7955193600
+expectedJsTimestamp = 7955193600;
+python.exec(`from datetime import timezone`)
+python.exec(`import datetime`);
+pyDate = python.eval(`datetime.datetime.fromtimestamp(${expectedJsTimestamp}, tz=timezone.utc)`);
+jsDate = throughJS(pyDate);
+
+if (jsDate.getTime() !== expectedJsTimestamp)
+{
+  console.error('expected', expectedJsTimestamp, 'but got',jsDate.getTime());
   throw new Error('test failed');
 }
 

--- a/tests/js/py2js/datetime.simple.failing
+++ b/tests/js/py2js/datetime.simple.failing
@@ -1,0 +1,23 @@
+/**
+ * @file        py2js/datetime.simple.failing
+ *              Simple test which shows that sending Python datetime.datetimes to JS and getting them back into
+ *              Python works as expected
+ * 
+ * @author      Elijah Deluzio, elijah@distributive.network
+ * @date        July 2023
+ */
+'use strict'
+
+python.exec(`import datetime`);
+const pyDate = python.eval(`datetime.datetime(1111, 2, 3)`);
+const jsDateExpected = new Date(1111, 2, 3);
+const throughJS = x => x;
+const jsDate = throughJS(pyDate);
+
+if (jsDate.getTime() !== jsDateExpected.getTime())
+{
+  console.error('expected', jsDate.getTime(), 'but got', pyDate.getTime());
+  throw new Error('test failed');
+}
+
+console.log('pass -', jsDate);


### PR DESCRIPTION
This feature is currently not supported, so it is expected to fail. Some interesting differences in values does happen when creating dates in each respective language however:

Node:
```
> const jsDate = new Date(1111, 2, 3)
undefined
> console.log(jsDate);
1111-03-03T05:17:32.000Z
> jsDate.getTime();
-27102192148000
```

Python:
```
>>> import datetime
>>> pyDate = datetime.datetime(1111, 2, 3)
>>> print(pyDate)
1111-02-03 00:00:00
>>> pyDate.timestamp()
-27104611348.0
```