### PR TITLE
chore(git): ignore local `.venv` folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ dist
 *.dylib
 *.dll
 *.pyd
+# Virtual Environment
+.venv/


### PR DESCRIPTION
When I use poetry, I configure it to create the project's virtual environment in the project, rather than under the cache directory [^1]. e.g.,

```console
$ poetry config --list | grep in-project
virtualenvs.in-project = true
```

This makes it easier to have tools like `rtx` auto activate the virtual environment whenever I `cd` into the project folder [^2], skipping the need to explicitly activate the shell or use `poetry run`.

It's also a commonly ignored file in Python projects [^3].

[^1]: https://python-poetry.org/docs/configuration/#virtualenvsin-project
[^2]: https://github.com/jdxcode/rtx/blob/v1.34.0/docs/python.md#experimental-automatic-virtualenv-creationactivation
[^3]: https://github.com/github/gitignore/blob/main/Python.gitignore