### PR TITLE
Add templates for GitHub issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_pythonmonkey.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_pythonmonkey.yaml
@@ -1,0 +1,80 @@
+name: File a Bug Report for PythonMonkey
+description: Use this template to report PythonMonkey-related issues. Thank you so much for making an issue!
+body:
+  - type: dropdown
+    id: issue-type
+    attributes:
+      label: Issue type
+      description: What type of issue would you like to report?
+      multiple: false
+      options:
+        - Bug
+        - Build/Install
+        - Performance
+        - Support
+        - Documentation Bug / Error
+        - Other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: source
+    attributes:
+      label: How did you install PythonMonkey?
+      options:
+        - Source
+        - Installed from pip
+        - Other (Please specify in additional info)
+
+  - type: input
+    id: OS
+    attributes:
+      label: OS platform and distribution
+      placeholder: e.g., Linux Ubuntu 22.04
+
+  - type: input
+    id: Python
+    attributes:
+      label: Python version (`python --version`)
+      placeholder: e.g., 3.9
+
+  - type: input
+    id: PythonMonkey
+    attributes:
+      label: PythonMonkey version
+      placeholder: 0.0.1.dev997+1eb883
+      description: You can also get this with `pmjs --version`.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: Bug Description
+      description: Please provide a clear and concise description of what the bug is.
+
+  - type: textarea
+    id: code-to-reproduce
+    attributes:
+      label: Standalone code to reproduce the issue
+      description: Provide a reproducible test case that is the bare minimum necessary to generate the problem.
+      value:
+      render: shell
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output or backtrace
+      description: Please copy and paste any relevant log output.
+      render: shell
+
+  - type: textarea
+    id: additional-info
+    attributes:
+      label: Additional info if applicable
+      description: Anything else to add.
+      render: shell
+
+  - type: input
+    id: brnach
+    attributes:
+      label: What branch of PythonMonkey were you developing on? (If applicable)
+      placeholder: main

--- a/.github/ISSUE_TEMPLATE/bug_pythonmonkey.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_pythonmonkey.yaml
@@ -74,7 +74,7 @@ body:
       render: shell
 
   - type: input
-    id: brnach
+    id: branch
     attributes:
       label: What branch of PythonMonkey were you developing on? (If applicable)
       placeholder: main

--- a/.github/ISSUE_TEMPLATE/bug_pythonmonkey.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_pythonmonkey.yaml
@@ -42,7 +42,7 @@ body:
     id: PythonMonkey
     attributes:
       label: PythonMonkey version
-      placeholder: 0.0.1.dev997+1eb883
+      placeholder: 0.2.0 or 0.0.1.dev997+1eb883
       description: You can also get this with `pmjs --version`.
 
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug_pythonmonkey.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_pythonmonkey.yaml
@@ -41,7 +41,7 @@ body:
   - type: input
     id: PythonMonkey
     attributes:
-      label: PythonMonkey version (`pip show pythonmonkey`)
+      label: PythonMonkey version (`python -c "import pythonmonkey as pm; print(pm.__version__)"`) 
       placeholder: 0.2.0 or 0.0.1.dev997+1eb883
       description: You can also get this with `pmjs --version`.
 

--- a/.github/ISSUE_TEMPLATE/bug_pythonmonkey.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_pythonmonkey.yaml
@@ -41,7 +41,7 @@ body:
   - type: input
     id: PythonMonkey
     attributes:
-      label: PythonMonkey version (`python -c "import pythonmonkey as pm; print(pm.__version__)"`) 
+      label: PythonMonkey version (`pip show pythonmonkey`)
       placeholder: 0.2.0 or 0.0.1.dev997+1eb883
       description: You can also get this with `pmjs --version`.
 

--- a/.github/ISSUE_TEMPLATE/bug_pythonmonkey.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_pythonmonkey.yaml
@@ -41,7 +41,7 @@ body:
   - type: input
     id: PythonMonkey
     attributes:
-      label: PythonMonkey version
+      label: PythonMonkey version (`pip show pythonmonkey`)
       placeholder: 0.2.0 or 0.0.1.dev997+1eb883
       description: You can also get this with `pmjs --version`.
 

--- a/.github/ISSUE_TEMPLATE/feature_pythonmonkey.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_pythonmonkey.yaml
@@ -1,0 +1,27 @@
+name: Make a Feature Request for PythonMonkey 
+description: Use this template to make feature requests for PythonMonkey. Thank you so much for making an issue!
+body:
+
+  - type: dropdown
+    id: source
+    attributes:
+      label: How did you install PythonMonkey?
+      options:
+        - Source
+        - Installed from pip
+        - Other (Please specify in additional info)
+
+  - type: textarea
+    id: feature-body
+    attributes:
+      label: 
+      description: Describe your feature request here.
+
+  - type: textarea
+    id: feature-code
+    attributes:
+      label: Code example
+      description: Provide a code example of this feature if applicable.
+      value:
+      render: shell
+

--- a/.github/ISSUE_TEMPLATE/feature_pythonmonkey.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_pythonmonkey.yaml
@@ -2,20 +2,11 @@ name: Make a Feature Request for PythonMonkey
 description: Use this template to make feature requests for PythonMonkey. Thank you so much for making an issue!
 body:
 
-  - type: dropdown
-    id: source
-    attributes:
-      label: How did you install PythonMonkey?
-      options:
-        - Source
-        - Installed from pip
-        - Other (Please specify in additional info)
-
   - type: textarea
     id: feature-body
     attributes:
-      label: 
-      description: Describe your feature request here.
+      label: Describe your feature request here.
+      description: Feel free to include diagrams drawings or anything else to help explain it.
 
   - type: textarea
     id: feature-code


### PR DESCRIPTION
This PR adds two templates to the PythonMonkey repository. One for feature requests and one for bug reports.

The bug report template was heavily inspired by and partially copied from [Tensorflow's `TensorFlow Issue Template` template](https://github.com/tensorflow/tensorflow/issues/new/choose).

---

You can view the proposed bug report and feature request issues here: [https://github.com/wiwichips/PythonMonkey/issues/new/choose](https://github.com/wiwichips/PythonMonkey/issues/new/choose). Feel free to test them out and see what they look like!

Here are screenshots:

![image](https://github.com/Distributive-Network/PythonMonkey/assets/18359452/9372b50f-c8ea-423e-9fbb-47492925ffbe)

![Screenshot 2023-07-18 at 09-59-52 New Issue · wiwichips_PythonMonkey](https://github.com/Distributive-Network/PythonMonkey/assets/18359452/f3e811e6-a6ad-44bf-8553-e9e1a14ddb44)

![image](https://github.com/Distributive-Network/PythonMonkey/assets/18359452/02439363-c7e8-4d3a-a7f8-6ac8720c3f2a)



