### PR TITLE
Fix non-BMP strings

### DIFF
--- a/include/StrType.hh
+++ b/include/StrType.hh
@@ -50,7 +50,7 @@ public:
    * @return PyObject* - the UCS4-encoding of the pyObject string
    *
    */
-  PyObject *asUCS4();
+  static PyObject *asUCS4(PyObject *pyObject);
 };
 
 #endif

--- a/include/modules/pythonmonkey/pythonmonkey.hh
+++ b/include/modules/pythonmonkey/pythonmonkey.hh
@@ -65,15 +65,6 @@ void handleSharedPythonMonkeyMemory(JSContext *cx, JSGCStatus status, JS::GCReas
 static PyObject *collect(PyObject *self, PyObject *args);
 
 /**
- * @brief Function exposed by the python module to convert UTF16 strings to UCS4 strings
- *
- * @param self - Pointer to the module object
- * @param args - Pointer to the python tuple of arguments (expected to contain a UTF16-encoded string as the first element)
- * @return PyObject* - A new python string in UCS4 encoding
- */
-static PyObject *asUCS4(PyObject *self, PyObject *args);
-
-/**
  * @brief Function exposed by the python module for evaluating arbitrary JS code
  *
  * @param self - Pointer to the module object

--- a/python/pythonmonkey/pythonmonkey.pyi
+++ b/python/pythonmonkey/pythonmonkey.pyi
@@ -16,15 +16,6 @@ def collect() -> None:
     Calls the spidermonkey garbage collector
     """
 
-@_typing.overload
-def asUCS4(utf16_str: str, /) -> str:
-    """
-    Expects a python string in UTF16 encoding, and returns a new equivalent string in UCS4.
-    Undefined behaviour if the string is not in UTF16.
-    """
-@_typing.overload
-def asUCS4(anything_else: _typing.Any, /) -> _typing.NoReturn: ...
-
 class bigint(int):
     """
     Representing JavaScript BigInt in Python

--- a/src/StrType.cc
+++ b/src/StrType.cc
@@ -103,7 +103,7 @@ StrType::StrType(JSContext *cx, JSString *str) {
 
     if (containsSurrogatePair(chars, length)) {
       // We must convert to UCS4 here because Python does not support decoding string containing surrogate pairs to bytes
-      PyObject *ucs4Obj = this->asUCS4(); // convert `pyObject` to a new PyUnicodeObject with UCS4 data
+      PyObject *ucs4Obj = asUCS4(pyObject); // convert to a new PyUnicodeObject with UCS4 data
       if (!ucs4Obj) {
         // conversion fails, keep the original `pyObject`
         return;
@@ -118,7 +118,8 @@ const char *StrType::getValue() const {
   return PyUnicode_AsUTF8(pyObject);
 }
 
-PyObject *StrType::asUCS4() {
+/* static */
+PyObject *StrType::asUCS4(PyObject *pyObject) {
   if (PyUnicode_KIND(pyObject) != PyUnicode_2BYTE_KIND) {
     return Py_NewRef(pyObject);
   }

--- a/src/modules/pythonmonkey/pythonmonkey.cc
+++ b/src/modules/pythonmonkey/pythonmonkey.cc
@@ -142,21 +142,6 @@ static PyObject *collect(PyObject *self, PyObject *args) {
   Py_RETURN_NONE;
 }
 
-static PyObject *asUCS4(PyObject *self, PyObject *args) {
-  PyObject *str = PyTuple_GetItem(args, 0);
-  if (!PyUnicode_Check(str)) {
-    PyErr_SetString(PyExc_TypeError, "pythonmonkey.asUCS4 expects a string as its first argument");
-    return NULL;
-  }
-
-  PyObject *ucs4Str = StrType::asUCS4(str);
-  if (!ucs4Str) {
-    PyErr_SetString(PyExc_UnicodeTranslateError, "string contains an unpaired surrogates");
-    return NULL;
-  }
-  return ucs4Str;
-}
-
 static bool getEvalOption(PyObject *evalOptions, const char *optionName, const char **s_p) {
   PyObject *value;
 
@@ -287,7 +272,6 @@ PyMethodDef PythonMonkeyMethods[] = {
   {"eval", eval, METH_VARARGS, "Javascript evaluator in Python"},
   {"isCompilableUnit", isCompilableUnit, METH_VARARGS, "Hint if a string might be compilable Javascript"},
   {"collect", collect, METH_VARARGS, "Calls the spidermonkey garbage collector"},
-  {"asUCS4", asUCS4, METH_VARARGS, "Expects a python string in UTF16 encoding, and returns a new equivalent string in UCS4. Undefined behaviour if the string is not in UTF16."},
   {NULL, NULL, 0, NULL}
 };
 

--- a/src/modules/pythonmonkey/pythonmonkey.cc
+++ b/src/modules/pythonmonkey/pythonmonkey.cc
@@ -149,7 +149,12 @@ static PyObject *asUCS4(PyObject *self, PyObject *args) {
     return NULL;
   }
 
-  return str->asUCS4();
+  PyObject *ucs4Str = str->asUCS4();
+  if (!ucs4Str) {
+    PyErr_SetString(PyExc_UnicodeTranslateError, "string contains an unpaired surrogates");
+    return NULL;
+  }
+  return ucs4Str;
 }
 
 static bool getEvalOption(PyObject *evalOptions, const char *optionName, const char **s_p) {

--- a/src/modules/pythonmonkey/pythonmonkey.cc
+++ b/src/modules/pythonmonkey/pythonmonkey.cc
@@ -143,13 +143,13 @@ static PyObject *collect(PyObject *self, PyObject *args) {
 }
 
 static PyObject *asUCS4(PyObject *self, PyObject *args) {
-  StrType *str = new StrType(PyTuple_GetItem(args, 0));
-  if (!PyUnicode_Check(str->getPyObject())) {
+  PyObject *str = PyTuple_GetItem(args, 0);
+  if (!PyUnicode_Check(str)) {
     PyErr_SetString(PyExc_TypeError, "pythonmonkey.asUCS4 expects a string as its first argument");
     return NULL;
   }
 
-  PyObject *ucs4Str = str->asUCS4();
+  PyObject *ucs4Str = StrType::asUCS4(str);
   if (!ucs4Str) {
     PyErr_SetString(PyExc_UnicodeTranslateError, "string contains an unpaired surrogates");
     return NULL;

--- a/tests/python/test_pythonmonkey_eval.py
+++ b/tests/python/test_pythonmonkey_eval.py
@@ -201,7 +201,7 @@ def test_eval_functions_ucs4_string_args():
             codepoint = random.randint(0x010000, 0x10FFFF)
             string2 += chr(codepoint)
         
-        assert pm.asUCS4(concatenate(string1, string2)) == (string1 + string2)
+        assert concatenate(string1, string2) == (string1 + string2)
 
 def test_eval_functions_roundtrip():
     # BF-60 https://github.com/Distributive-Network/PythonMonkey/pull/18

--- a/tests/python/test_strings.py
+++ b/tests/python/test_strings.py
@@ -29,8 +29,7 @@ def test_eval_unpaired_surrogate_string_matches_evaluated_string():
 
 def test_eval_ucs4_string_matches_evaluated_string():
     py_ucs4_string = "🀄🀛🜢"
-    js_utf16_string = pm.eval(repr(py_ucs4_string))
-    js_ucs4_string = pm.asUCS4(js_utf16_string)
+    js_ucs4_string = pm.eval(repr(py_ucs4_string))
     assert py_ucs4_string == js_ucs4_string
 
 def test_eval_latin1_string_fuzztest():
@@ -111,8 +110,7 @@ def test_eval_ucs4_string_fuzztest():
         INITIAL_STRING = string1
         m = 10
         for _ in range(m):
-            utf16_string2 = pm.eval("'" + string1 + "'")
-            string2 = pm.asUCS4(utf16_string2)
+            string2 = pm.eval("'" + string1 + "'")
             assert len(string1) == length
             assert len(string2) == length
             assert len(string1) == len(string2)
@@ -158,8 +156,7 @@ def test_eval_boxed_unpaired_surrogate_string_matches_evaluated_string():
 
 def test_eval_boxed_ucs4_string_matches_evaluated_string():
     py_ucs4_string = "🀄🀛🜢"
-    js_utf16_string = pm.eval(f'new String({repr(py_ucs4_string)})')
-    js_ucs4_string = pm.asUCS4(js_utf16_string)
+    js_ucs4_string = pm.eval(f'new String({repr(py_ucs4_string)})')
     assert py_ucs4_string == js_ucs4_string
 
 def test_eval_boxed_latin1_string_fuzztest():
@@ -240,8 +237,7 @@ def test_eval_boxed_ucs4_string_fuzztest():
         INITIAL_STRING = string1
         m = 10
         for _ in range(m):
-            utf16_string2 = pm.eval(f'new String("{string1}")')
-            string2 = pm.asUCS4(utf16_string2)
+            string2 = pm.eval(f'new String("{string1}")')
             assert len(string1) == length
             assert len(string2) == length
             assert len(string1) == len(string2)


### PR DESCRIPTION
Fixes https://github.com/Distributive-Network/PythonMonkey/issues/89

* Convert strings that require conversion to UCS4 automatically to avoid surprises.
* Remove `pm.asUCS4` method as encoding conversion is done automatically