### PR TITLE
console.js - use own props instead of inheritance 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ dist
 *.dylib
 *.dll
 *.pyd
+*~

--- a/python/pythonmonkey/builtin_modules/console.js
+++ b/python/pythonmonkey/builtin_modules/console.js
@@ -54,8 +54,8 @@ class Console {
     this.log   = (...args) => this.#writeToStdout(this.#formatToStr(...args));
     this.debug = (...args) => this.#writeToStdout(this.#formatToStr(...args));
     this.info  = (...args) => this.#writeToStdout(this.#formatToStr(...args));
-    this.warn  = (...args) => this.#writeToStdout(this.#formatToStr(...args));
-    this.error = (...args) => this.#writeToStdout(this.#formatToStr(...args));
+    this.warn  = (...args) => this.#writeToStderr(this.#formatToStr(...args));
+    this.error = (...args) => this.#writeToStderr(this.#formatToStr(...args));
   }
 
   /**

--- a/python/pythonmonkey/builtin_modules/console.js
+++ b/python/pythonmonkey/builtin_modules/console.js
@@ -11,8 +11,6 @@ const { customInspectSymbol, format } = require("util");
 /**
  * @see https://developer.mozilla.org/en-US/docs/Web/API/Console_API
  */
-// TODO (Tom Tang): It's easier to copy implementations from Node.js version 8 than Node.js 20,
-//                  see https://github.com/nodejs/node/blob/v8.17.0/lib/console.js
 // TODO (Tom Tang): adhere https://console.spec.whatwg.org/
 class Console {
   /** @type {WriteFn} */
@@ -49,8 +47,15 @@ class Console {
         ignoreErrors = true;
       options = { stdout, stderr, ignoreErrors };
     }
+
     this.#writeToStdout = options.stdout.write;
     this.#writeToStderr = options.stderr.write;
+
+    this.log   = (...args) => this.#writeToStdout(this.#formatToStr(...args));
+    this.debug = (...args) => this.#writeToStdout(this.#formatToStr(...args));
+    this.info  = (...args) => this.#writeToStdout(this.#formatToStr(...args));
+    this.warn  = (...args) => this.#writeToStdout(this.#formatToStr(...args));
+    this.error = (...args) => this.#writeToStdout(this.#formatToStr(...args));
   }
 
   /**
@@ -58,14 +63,6 @@ class Console {
    */
   #formatToStr(...args) {
     return format(...args) + "\n"
-  }
-
-  log(...args) {
-    this.#writeToStdout(this.#formatToStr(...args))
-  }
-
-  warn(...args) {
-    this.#writeToStderr(this.#formatToStr(...args))
   }
 
   // TODO (Tom Tang): implement more methods
@@ -82,11 +79,6 @@ class Console {
    */
   static customInspectSymbol = customInspectSymbol;
 }
-
-// https://github.com/nodejs/node/blob/v20.1.0/lib/internal/console/constructor.js#L681-L685
-Console.prototype.debug = Console.prototype.log;
-Console.prototype.info = Console.prototype.log;
-Console.prototype.error = Console.prototype.warn;
 
 if (!globalThis.console) {
   globalThis.console = new Console(

--- a/tests/js/console-stdio.bash
+++ b/tests/js/console-stdio.bash
@@ -1,0 +1,45 @@
+#! /bin/bash
+#
+# @file         console-stdio.bash
+#               A peter-jr test which ensures that the console object uses the right file descriptors.
+#
+# @author       Wes Garland, wes@distributive.network
+# @date         July 2023
+
+set -u
+set -o pipefail
+
+panic()
+{
+  echo "FAIL: $*" >&2
+  exit 2
+}
+
+cd `dirname "$0"` || panic "could not change to test directory"
+
+"${PMJS:-../../pmjs}" \
+-e 'console.log("stdout")' \
+-e 'console.debug("stdout")' \
+-e 'console.info("stdout")' \
+< /dev/null \
+| grep -c '^stdout$' \
+| while read qty
+  do
+    echo "stdout: $qty"
+    [ "$qty" != "3" ] && panic qty should not be $qty
+    break
+  done || exit $?
+
+"${PMJS:-../../pmjs}" \
+-e 'console.error("stderr")' \
+-e 'console.warn("stderr")' \
+< /dev/null 2>&1 \
+| grep -c '^stderr$' \
+| while read qty
+  do
+    echo "stderr: $qty"
+    [ "$qty" != "2" ] && panic qty should not be $qty
+    break
+  done || exit $?
+
+echo "done"

--- a/tests/js/console-this.simple
+++ b/tests/js/console-this.simple
@@ -15,7 +15,7 @@ function assert(test)
   if (!test)
   {
     exitCode = 1;
-    console.error(new Error('Assertion failure').stack);
+    console.error(new Error('Assertion failure'));
   }
 }
 

--- a/tests/js/console-this.simple
+++ b/tests/js/console-this.simple
@@ -1,0 +1,40 @@
+/**
+ * @file        console-this.simple
+ *
+ *              Test which ensures that the Console objects have unique own properties and bound this.
+ *              Regression test for issue #90.
+ *
+ * @author      Wes Garland, wes@distributive.network
+ * @date        July 2023
+ */
+'use strict';
+
+var exitCode = 0;
+function assert(test)
+{
+  if (!test)
+  {
+    exitCode = 1;
+    console.error(new Error('Assertion failure').stack);
+  }
+}
+
+const c = console;
+
+assert(c.log  !== c.debug);
+assert(c.log  !== c.warn);
+assert(c.log  !== c.info);
+assert(c.warn !== c.error);
+assert(typeof c.log   === 'function');
+assert(typeof c.debug === 'function');
+assert(typeof c.info  === 'function');
+assert(typeof c.error === 'function');
+assert(typeof c.warn  === 'function');
+assert(c.hasOwnProperty('debug'));
+assert(c.hasOwnProperty('log'));
+assert(c.hasOwnProperty('info'));
+assert(c.hasOwnProperty('warn'));
+assert(c.hasOwnProperty('error'));
+
+c.log('test done'); /* throws if wrong this, issue #90 */
+python.exit(exitCode);

--- a/tests/js/is-compilable-unit.simple
+++ b/tests/js/is-compilable-unit.simple
@@ -1,5 +1,5 @@
 /**
- * @file        is-compilabe-unit.simple
+ * @file        is-compilable-unit.simple
  *              Simple test which ensures that pm.isCompilableUnit works from JS as expected
  *              written in Python instead of JavaScript
  * @author      Wes Garland, wes@distributive.network


### PR DESCRIPTION
Issue 90 is because of unbound `this`
Current version of NodeJS use ownProperties for the different methods of console, and some DCP code depends on this.

I added a test to test this stuff, and it passes on node 14, as well as pmjs now.