### PR TITLE
Bugfix: Exit with code 0 for failures with .failing tests

### DIFF
--- a/peter-jr
+++ b/peter-jr
@@ -164,6 +164,10 @@ findTests \
       echo "${FAIL}"
       peter_exit_code=1
 
+      if [ "$knownFail" ]; then
+        peter_exit_code=0
+      fi
+
       if [ ! "$VERBOSE" ] && [ ! "$knownFail" ]; then
         echo
         echo "$(grey --) $(yellow ${file}) $(grey vvvvvvvvvvvvvv)"


### PR DESCRIPTION
This PR makes `.failing` tests exit with code 0 to make Peter Jr. model the same behaviour as Peter. Like father, like son.

This PR resolves issue #102.