### PR TITLE
fix(build.py): build.py doesn't assume location

### DIFF
--- a/build.py
+++ b/build.py
@@ -6,6 +6,7 @@
 import subprocess
 import os, sys
 import platform
+from typing import Optional
 
 TOP_DIR = os.path.abspath(os.path.dirname(__file__))
 BUILD_DIR = os.path.join(TOP_DIR, "build")
@@ -13,9 +14,9 @@ BUILD_DIR = os.path.join(TOP_DIR, "build")
 # Get number of CPU cores
 CPUS = os.cpu_count() or 1
 
-def execute(cmd: str):
+def execute(cmd: str, cwd: Optional[str] = None):
     popen = subprocess.Popen(cmd, stdout = subprocess.PIPE, stderr = subprocess.STDOUT,
-        shell = True, text = True )
+        shell = True, text = True, cwd = cwd )
     for stdout_line in iter(popen.stdout.readline, ""):
         sys.stdout.write(stdout_line)
         sys.stdout.flush()
@@ -27,33 +28,31 @@ def execute(cmd: str):
 
 def ensure_spidermonkey():
     # Check if SpiderMonkey libs already exist
-    spidermonkey_lib_exist = os.path.exists("./_spidermonkey_install/lib")
+    spidermonkey_lib_exist = os.path.exists(os.path.join( TOP_DIR, "_spidermonkey_install/lib" ))
     if spidermonkey_lib_exist:
         return
 
     # Build SpiderMonkey
-    execute("bash ./setup.sh")
+    execute("bash ./setup.sh", cwd = TOP_DIR)
 
 def run_cmake_build():
     os.makedirs(BUILD_DIR, exist_ok=True) # mkdir -p
-    os.chdir(BUILD_DIR)
     if platform.system() == "Windows":
-        execute("cmake .. -T ClangCL") # use Clang/LLVM toolset for Visual Studio
+        execute("cmake .. -T ClangCL", cwd=BUILD_DIR) # use Clang/LLVM toolset for Visual Studio
     else:
-        execute("cmake ..")
-    execute(f"cmake --build . -j{CPUS} --config Release")
-    os.chdir(TOP_DIR)
+        execute("cmake ..", cwd=BUILD_DIR)
+    execute(f"cmake --build . -j{CPUS} --config Release", cwd=BUILD_DIR)
 
 def copy_artifacts():
     if platform.system() == "Windows":
-        execute("cp ./build/src/*/pythonmonkey.pyd ./python/pythonmonkey/") # Release or Debug build
-        execute("cp ./_spidermonkey_install/lib/mozjs-*.dll ./python/pythonmonkey/")
+        execute("cp ./build/src/*/pythonmonkey.pyd ./python/pythonmonkey/", cwd=TOP_DIR) # Release or Debug build
+        execute("cp ./_spidermonkey_install/lib/mozjs-*.dll ./python/pythonmonkey/", cwd=TOP_DIR)
     else:
-        execute("cp ./build/src/pythonmonkey.so ./python/pythonmonkey/")
-        execute("cp ./_spidermonkey_install/lib/libmozjs* ./python/pythonmonkey/")
+        execute("cp ./build/src/pythonmonkey.so ./python/pythonmonkey/", cwd=TOP_DIR)
+        execute("cp ./_spidermonkey_install/lib/libmozjs* ./python/pythonmonkey/", cwd=TOP_DIR)
 
 def build():
-    execute("git submodule update --init --recursive")
+    execute("git submodule update --init --recursive", cwd=TOP_DIR)
     ensure_spidermonkey()
     run_cmake_build()
     copy_artifacts()


### PR DESCRIPTION
Build.py was originally assuming we were at the project root for a few things, this is no longer the case and build.py makes sure to start the child processes in the right locations. 