### PR TITLE
Wes/small fixes

### DIFF
--- a/python/pythonmonkey/require.py
+++ b/python/pythonmonkey/require.py
@@ -48,7 +48,8 @@ globalThis.pmEval = pm.eval
 globalThis.python.pythonMonkey.dir = os.path.dirname(__file__)
 #globalThis.python.pythonMonkey.version = pm.__version__
 #globalThis.python.pythonMonkey.module = pm
-globalThis.python.pythonMonkey.isCompilableUnit = pm.isCompilableUnit;
+globalThis.python.pythonMonkey.isCompilableUnit = pm.isCompilableUnit
+globalThis.python.pythonMonkey.nodeModules = node_modules
 globalThis.python.print  = print
 globalThis.python.stdout.write = sys.stdout.write
 globalThis.python.stderr.write = sys.stderr.write
@@ -272,10 +273,15 @@ function createRequire(filename, bootstrap_broken, extraPaths, isMain)
     module.exports = python.load(filename);
   }
 
+  if (moduleCache[filename])
+    return moduleCache[filename].require;
+
   const module = new CtxModule(globalThis, filename, moduleCache);
+  moduleCache[filename] = module;
   for (let path of python.paths)
     module.paths.push(path + '/node_modules');
   module.require.path.push(python.pythonMonkey.dir + '/builtin_modules');
+  module.require.path.push(python.pythonMonkey.nodeModules);
   module.require.extensions['.py'] = loadPythonModule;
 
   if (isMain)

--- a/tests/js/pmjs-popt.bash
+++ b/tests/js/pmjs-popt.bash
@@ -27,7 +27,7 @@ do
       exit 111
       ;;
     *)
-      echo "Ignored: ${keyword} ${rest} (${loaded})"
+      echo "Ignored: ${keyword} ${rest}"
       ;;
   esac
 done

--- a/tests/js/pmjs-ropt.bash
+++ b/tests/js/pmjs-ropt.bash
@@ -27,7 +27,7 @@ do
       exit 111
       ;;
     *)
-      echo "Ignored: ${keyword} ${rest} (${loaded})"
+      echo "Ignored: ${keyword} ${rest}"
       ;;
   esac
 done


### PR DESCRIPTION
This is a series of small cherry-picks that are on stalled branches.
- inspect(Error) supports .code better
- bugfixes in for two pmjs tests
- createRequire(filename) always returns the same require object from JS POV (should make it okay to leave Python LRU cache in place)
- `pminit npm i X` will now be `require(X)` in pmjs