### PR TITLE
feature(tests): add js py2js and js2py error conversion test

### DIFF
--- a/tests/js/js2py/error.simple
+++ b/tests/js/js2py/error.simple
@@ -1,0 +1,48 @@
+/**
+ * @file        js2py/string.simple
+ *              Ensures that an error constructed in PY and binded to JS retains error message.
+ *              Error properties are not retained.
+ * 
+ * @author      David Courtis, david@distributive.network
+ * @date        July 2023
+ */
+'use strict';
+
+const throughJS = x => x; 
+let errorFlag = false;
+
+function tester(exceptionpy, exceptionjs) {
+  if (!exceptionpy.toString() === exceptionjs.toString())
+  {
+    console.error('Expected\n', exceptionpy.toString(), '\nbut got\n', exceptionjs.toString());
+    errorFlag = true;
+  } else {
+    console.log('pass -', exceptionpy.toString());
+  }
+}
+
+function inbuiltError() {
+  const exceptionpy = python.eval(`Exception('I know Python!')`);
+  const exceptionjs = throughJS(exceptionpy);
+  tester(exceptionpy, exceptionjs);
+}
+
+function customError() {
+  python.exec(
+    `class IAmAnError(Exception):
+      def __init__(self, message):            
+        super().__init__(message)
+    `
+    );
+  const exceptionpy = python.eval(`IAmAnError('I know Python!')`);
+  const exceptionjs = throughJS(exceptionpy);
+  tester(exceptionpy, exceptionjs);
+}
+
+inbuiltError();
+customError();
+
+if (errorFlag) {
+  throw new Error('test failed');
+}
+

--- a/tests/js/py2js/error.simple
+++ b/tests/js/py2js/error.simple
@@ -1,0 +1,26 @@
+/**
+ * @file        py2js/string.simple
+ *              Ensures that an error constructed in JS and passed through python retains error message.
+ *              There will be a lossful conversion of error properties from JS to Py.
+ * 
+ * @author      David Courtis, david@distributive.network
+ * @date        July 2023
+ */
+'use strict';
+
+class RandomError extends Error {
+  constructor(message) {
+    super(message);
+  }
+}
+
+const exceptionjs = new RandomError("I was created!");
+const throughPython = python.eval('(lambda x: x)');
+const exceptionpy = throughPython(exceptionjs);
+
+if (!exceptionpy.toString().includes(exceptionjs.toString())) {
+  console.error('Expected\n', exceptionjs.toString(), '\nbut got\n', exceptionpy.toString());
+  throw new Error('test failed');
+}
+
+console.log('pass -', exceptionjs);


### PR DESCRIPTION
Added the Error object conversion test.

Note that the custom properties on these errors are not preserved in either case. 
This behaviour is currently intended but may be subject to change in the future, thereby, these tests should be updated to test that behaviour accordingly.