### PR TITLE
fix: stdio stream objects may be monkeypatched at runtime not being instances of TextIOWrapper

### DIFF
--- a/python/pythonmonkey/require.py
+++ b/python/pythonmonkey/require.py
@@ -45,9 +45,9 @@ evalOpts = { 'filename': __file__, 'fromPythonFrame': True } # type: pm.EvalOpti
 
 # Force to use UTF-8 encoding
 # Windows may use other encodings / code pages that have many characters missing/unrepresentable
-# Error: Python UnicodeEncodeError: 'charmap' codec can't encode characters in position xx-xx: character maps to <undefined>
-sys.stdout.reconfigure(encoding='utf-8')
-sys.stderr.reconfigure(encoding='utf-8')
+if isinstance(sys.stdin,  io.TextIOWrapper): sys.stdin.reconfigure(encoding='utf-8')
+if isinstance(sys.stdout, io.TextIOWrapper): sys.stdout.reconfigure(encoding='utf-8')
+if isinstance(sys.stderr, io.TextIOWrapper): sys.stderr.reconfigure(encoding='utf-8')
 
 # Add some python functions to the global python object for code in this file to use.
 globalThis = pm.eval("globalThis;", evalOpts)


### PR DESCRIPTION
In Google Colab
```
!pip install pythonmonkey
```
```py
import pythonmonkey as pm
```
```console
/usr/local/lib/python3.10/dist-packages/pythonmonkey/require.py in <module>
     47 # Windows may use other encodings / code pages that have many characters missing/unrepresentable
     48 # Error: Python UnicodeEncodeError: 'charmap' codec can't encode characters in position xx-xx: character maps to <undefined>
---> 49 sys.stdout.reconfigure(encoding='utf-8')
     50 sys.stderr.reconfigure(encoding='utf-8')
     51 

AttributeError: 'OutStream' object has no attribute 'reconfigure'
```