### PR TITLE
A pm.new and other helpers

### DIFF
--- a/python/pythonmonkey/__init__.py
+++ b/python/pythonmonkey/__init__.py
@@ -1,6 +1,7 @@
 # Export public PythonMonkey APIs
 from .pythonmonkey import *
 from .require import *
+from .helpers import *
 
 # Expose the package version
 import importlib.metadata
@@ -24,4 +25,4 @@ pythonmonkey.eval("""
   Object.defineProperty(Object.prototype, "keys", keysMethod)
   Object.defineProperty(Array.prototype, "keys", keysMethod)
 }
-""")(lambda *args: list(args))
+""", { 'filename': __file__, 'fromPythonFrame': True })(lambda *args: list(args))

--- a/python/pythonmonkey/__init__.py
+++ b/python/pythonmonkey/__init__.py
@@ -1,7 +1,7 @@
 # Export public PythonMonkey APIs
 from .pythonmonkey import *
-from .require import *
 from .helpers import *
+from .require import *
 
 # Expose the package version
 import importlib.metadata

--- a/python/pythonmonkey/helpers.py
+++ b/python/pythonmonkey/helpers.py
@@ -1,0 +1,49 @@
+# @file         helpers.py - Python->JS helpers for PythonMonkey
+#               - typeof operator wrapper
+#               - new operator wrapper
+#
+# @author       Wes Garland, wes@distributive.network
+# @date         July 2023
+#
+
+from . import pythonmonkey as pm 
+evalOpts = { 'filename': __file__, 'fromPythonFrame': True }
+
+def typeof(jsval):
+    """
+    typeof function - wraps JS typeof operator
+    """
+    return pm.eval("""'use strict'; (
+function pmTypeof(jsval) 
+{
+  return typeof(jsval)
+}
+    )""", evalOpts)(jsval);
+
+def new(ctor, *args):
+    """
+    new function - wraps JS new operator
+    """
+    if (typeof(ctor) == 'string'):
+        ctor = pm.eval(ctor)
+
+    return pm.eval("""'use strict'; (
+function pmNew(ctor, args) 
+{
+  if (arguments.length === 1)
+    args = [];
+  
+  // work around pm list->Array bug, /wg july 2023
+  if (!Array.isArray(args))
+  {
+    const newArgs = [];
+    for (let i=0; i < args.length; i++)
+      newArgs[i] = args[i];
+    args = newArgs;    
+  }
+  return new ctor(...args);
+}
+    )""", evalOpts)(ctor, list(args));
+
+# Restrict what symbols are exposed to the pythonmonkey module.
+__all__ = ["new", "typeof"]

--- a/python/pythonmonkey/helpers.py
+++ b/python/pythonmonkey/helpers.py
@@ -42,16 +42,17 @@ function pmNewFactory(ctor)
 # List which symbols are exposed to the pythonmonkey module.
 __all__ = [ "new", "typeof" ]
 
-# Add the properties of globalThis (except eval) as exports:
+# Add the non-enumerable properties of globalThis which don't collide with pythonmonkey.so as exports:
 globalThis = pm.eval('globalThis');
+pmGlobals = vars(pm)
 
 exports = pm.eval("""
 Object.getOwnPropertyNames(globalThis)
-.filter(prop => prop !== 'eval')
-.filter(prop => prop[0] !== '_')
-""")
+.filter(prop => Object.keys(globalThis).indexOf(prop) === -1);
+""", evalOpts)
 
 for index in range(0, int(exports.length)):
     name = exports[index]
-    globals().update({name: globalThis[name]})
-    __all__.append(name)
+    if (pmGlobals.get(name) == None):
+        globals().update({name: globalThis[name]})
+        __all__.append(name)

--- a/python/pythonmonkey/helpers.py
+++ b/python/pythonmonkey/helpers.py
@@ -49,10 +49,9 @@ exports = pm.eval("""
 Object.getOwnPropertyNames(globalThis)
 .filter(prop => prop !== 'eval')
 .filter(prop => prop[0] !== '_')
-.filter(prop => Object.keys(globalThis).indexOf(prop) === -1)
 """)
 
-for index in range(0, int(exports.length) - 1):
+for index in range(0, int(exports.length)):
     name = exports[index]
     globals().update({name: globalThis[name]})
     __all__.append(name)

--- a/python/pythonmonkey/require.py
+++ b/python/pythonmonkey/require.py
@@ -352,5 +352,5 @@ def require(moduleIdentifier: str):
       filename = os.path.join(os.getcwd(), "__main__") # use the CWD instead
     return createRequire(filename)(moduleIdentifier)
 
-# Restrict what are exposed to the pythonmonkey module.
+# Restrict what symbols are exposed to the pythonmonkey module.
 __all__ = ["globalThis", "require", "createRequire", "runProgramModule"]


### PR DESCRIPTION
- basically everything in an "empty" global (like Array, WebAssembly, Uint8Array, escape, Date, etc) is now an export of pythonmonkey
- new and typeof operators are wrapped in functions for pythonic use
```
>>> import pythonmonkey as pm
>>> a=pm.new(pm.Uint8Array)([3,4,5])
>>> a
<memory at 0x7fe4415e93c0>
```