### PR TITLE
Feat: pmdb, a gdb-like JavaScript debugger interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,9 +350,34 @@ exports['today'] = date.today()
 ## CommonJS (require)
 If you are having trouble with the CommonJS require function, set environment variable `DEBUG='ctx-module*'` and you can see the filenames it tries to laod.
 
+## pmdb
+
+PythonMonkey has a built-in gdb-like JavaScript command-line debugger called **pmdb**, which would be automatically triggered on `debugger;` statements and uncaught exceptions.
+
+To enable **pmdb**, simply call `from pythonmonkey.lib import pmdb; pmdb.enable()` before doing anything on PythonMonkey.
+
+```py
+import pythonmonkey as pm
+from pythonmonkey.lib import pmdb
+
+pmdb.enable()
+
+pm.eval("...")
+```
+
+Run `help` command in **pmdb** to see available commands.
+
+```console
+(pmdb) > help
+List of commands:
+• ...
+• ...
+```
+
 ## pmjs
 - there is a `.help` menu in the REPL
 - there is a `--help` command-line option
+- the `--inspect` option enables **pmdb**, a gdb-like JavaScript command-line debugger
 - the `-r` option can be used to load a module before your program or the REPL runs
 - the `-e` option can be used evaluate code -- e.g. define global variables -- before your program or the REPL runs
 - The REPL can evaluate Python expressions, storing them in variables named `$1`, `$2`, etc.

--- a/python/pythonmonkey/cli/pmjs.py
+++ b/python/pythonmonkey/cli/pmjs.py
@@ -323,7 +323,7 @@ def main():
     global requirePath
     
     try:
-        opts, args = getopt.getopt(sys.argv[1:], "hie:p:r:v", ["help", "eval=", "print=", "require=", "version", "use-strict", "inspect"])
+        opts, args = getopt.getopt(sys.argv[1:], "hie:p:r:v", ["help", "eval=", "print=", "require=", "version", "interactive", "use-strict", "inspect"])
     except getopt.GetoptError as err:
         # print help information and exit:
         print(err)  # will print something like "option -a not recognized"

--- a/python/pythonmonkey/cli/pmjs.py
+++ b/python/pythonmonkey/cli/pmjs.py
@@ -6,6 +6,8 @@
 import sys, os, signal, getopt
 import readline
 import pythonmonkey as pm
+from pythonmonkey.lib.pmdb import pmdbEnable
+
 globalThis = pm.eval("globalThis")
 evalOpts = { 'filename': __file__, 'fromPythonFrame': True, 'strict': False } # type: pm.EvalOptions
 
@@ -287,6 +289,7 @@ Options:
   -r, --require...     module to preload (option can be repeated)
   -v, --version        print PythonMonkey version
   --use-strict         evaluate -e, -p, and REPL code in strict mode
+  --inspect            enable pmdb, a gdb-like JavaScript debugger interface
   
 Environment variables:
 TZ                            specify the timezone configuration
@@ -320,7 +323,7 @@ def main():
     global requirePath
     
     try:
-        opts, args = getopt.getopt(sys.argv[1:], "hie:p:r:v", ["help", "eval=", "print=", "require=", "version", "use-strict"])
+        opts, args = getopt.getopt(sys.argv[1:], "hie:p:r:v", ["help", "eval=", "print=", "require=", "version", "use-strict", "inspect"])
     except getopt.GetoptError as err:
         # print help information and exit:
         print(err)  # will print something like "option -a not recognized"
@@ -347,6 +350,8 @@ def main():
             enterRepl = False
         elif o in ("-r", "--require"):
             globalThis.require(a)
+        elif o in ("--inspect"):
+            pmdbEnable(pm.eval("debuggerGlobal"))
         else:
             assert False, "unhandled option"
 

--- a/python/pythonmonkey/cli/pmjs.py
+++ b/python/pythonmonkey/cli/pmjs.py
@@ -6,7 +6,7 @@
 import sys, os, signal, getopt
 import readline
 import pythonmonkey as pm
-from pythonmonkey.lib.pmdb import pmdbEnable
+from pythonmonkey.lib import pmdb
 
 globalThis = pm.eval("globalThis")
 evalOpts = { 'filename': __file__, 'fromPythonFrame': True, 'strict': False } # type: pm.EvalOptions
@@ -351,7 +351,7 @@ def main():
         elif o in ("-r", "--require"):
             globalThis.require(a)
         elif o in ("--inspect"):
-            pmdbEnable(pm.eval("debuggerGlobal"))
+            pmdb.enable()
         else:
             assert False, "unhandled option"
 

--- a/python/pythonmonkey/lib/pmdb.py
+++ b/python/pythonmonkey/lib/pmdb.py
@@ -15,6 +15,10 @@ def debuggerInput(prompt: str):
     return ""
 
 def enable(debuggerGlobalObject = pm.eval("debuggerGlobal")):
+  if debuggerGlobalObject._pmdbEnabled:
+    return # already enabled, skipping
+
+  debuggerGlobalObject._pmdbEnabled = True
   debuggerGlobalObject.eval("""(debuggerInput, _pythonPrint, _pythonExit) => {
   const dbg = new Debugger()
   const mainDebuggee = dbg.addDebuggee(mainGlobal)

--- a/python/pythonmonkey/lib/pmdb.py
+++ b/python/pythonmonkey/lib/pmdb.py
@@ -85,6 +85,10 @@ def enable(debuggerGlobalObject = pm.eval("debuggerGlobal")):
         case "exec":
         case "print": {
           // Execute an expression in debugging script's context and print its value
+          if (!rest) {
+            print(`"print <expr>" command requires an argument.`)
+            continue blockingLoop;
+          }
           const result = frame.eval(rest)
           if (result.throw) printErr(result.throw) // on error
           else print(result.return) // on success

--- a/python/pythonmonkey/lib/pmdb.py
+++ b/python/pythonmonkey/lib/pmdb.py
@@ -1,0 +1,109 @@
+# @file     pmdb - A gdb-like JavaScript debugger interface for pmjs
+#                  Enabled by `pmjs --inspect`
+# @author   Tom Tang <xmader@distributive.network>
+# @date     July 2023
+
+def debuggerInput(prompt: str):
+  try:
+    return input(prompt) # blocking
+  except KeyboardInterrupt:
+    print("\b\bQuit") # to match the behaviour of gdb 
+    return ""
+  except Exception as e:
+    print(e)
+    return ""
+
+def pmdbEnable(debuggerGlobalObject):
+  debuggerGlobalObject.eval("""(debuggerInput, _pythonPrint) => {
+  const dbg = new Debugger()
+  const mainDebuggee = dbg.addDebuggee(mainGlobal)
+  dbg.uncaughtExceptionHook = (e) => {
+    _pythonPrint(e)
+  }
+
+  function makeDebuggeeValue (val) {
+    if (val instanceof Debugger.Object) {
+      return dbg.adoptDebuggeeValue(val)
+    } else {
+      // See https://firefox-source-docs.mozilla.org/js/Debugger/Debugger.Object.html#makedebuggeevalue-value
+      return mainDebuggee.makeDebuggeeValue(val)
+    }
+  }
+
+  function print (...args) {
+    const logger = makeDebuggeeValue(mainGlobal.console.log)
+    logger.apply(logger, args.map(makeDebuggeeValue))
+  }
+  
+  function printErr (...args) {
+    const logger = makeDebuggeeValue(mainGlobal.console.error)
+    logger.apply(logger, args.map(makeDebuggeeValue))
+  }
+  
+  function getCommandInputs () {
+    const input = debuggerInput("(pmdb) > ") // blocking
+    const [_, command, rest] = input.match(/\\s*(\\w+)?(?:\\s+(.*))?/)
+    return { command, rest }
+  }
+
+  function enterDebuggerLoop (frame) {
+    const metadata = frame.script.getOffsetMetadata(frame.offset)
+    if (!metadata.isBreakpoint) {
+      // This bytecode offset does not qualify as a breakpoint, skipping
+      return
+    }
+    
+    blockingLoop: while (true) {
+      const { command, rest } = getCommandInputs() // blocking
+      switch (command) {
+        case "c":
+        case "cont":
+          // Continue execution until next breakpoint or `debugger` statement
+          frame.onStep = undefined // clear step next handler
+          break blockingLoop;
+        case "n":
+        case "next":
+          // Step next
+          frame.onStep = function () { enterDebuggerLoop(this) } // add handler
+          break blockingLoop;
+        case "bt":
+        case "backtrace":
+          // Print backtrace of current execution frame
+          // FIXME: we currently implement this using Error.stack
+          print(frame.eval("(new Error).stack.split('\\\\n').slice(1).join('\\\\n')").return)
+          continue blockingLoop;
+        case "l":
+        case "line": {
+          // Print current line
+          const src = frame.script.source.text
+          const line = src.split('\\n').slice(metadata.lineNumber-1, metadata.lineNumber).join('\\n')
+          print(line)
+          continue blockingLoop;
+        }
+        case "p":
+        case "exec":
+        case "print": {
+          // Execute an expression in debugging script's context and print its value
+          const result = frame.eval(rest)
+          if (result.throw) printErr(result.throw) // on error
+          else print(result.return) // on success
+          continue blockingLoop;
+        }
+        case "q":
+        case "quit":
+        case "kill":
+          // Force exit the program
+          mainGlobal.python.exit(127)
+          break blockingLoop;
+        case "":
+        case undefined:
+          // no-op
+          continue blockingLoop;
+        default:
+          print(`Undefined command: "${command}"`)
+      }
+    }
+  }
+
+  dbg.onDebuggerStatement = (frame) => enterDebuggerLoop(frame)
+  }""")(debuggerInput, print)

--- a/python/pythonmonkey/lib/pmdb.py
+++ b/python/pythonmonkey/lib/pmdb.py
@@ -96,12 +96,27 @@ def enable(debuggerGlobalObject = pm.eval("debuggerGlobal")):
           // Force exit the program
           mainGlobal.python.exit(127)
           break blockingLoop;
+        case "h":
+        case "help":
+          // Print help message
+          // XXX: keep this in sync with the actual implementation
+          print([
+            "List of commands:",
+            "• c/cont: Continue execution until next breakpoint or debugger statement",
+            "• n/next: Step next",
+            "• bt/backtrace: Print backtrace of current execution frame",
+            "• l/line: Print current line",
+            "• p <expr>/print <expr>/exec <expr>: Execute an expression in debugging script's context and print its value",
+            "• q/quit/kill: Force exit the program",
+            "• h/help: Print help message",
+          ].join("\\n"))
+          continue blockingLoop;
         case "":
         case undefined:
           // no-op
           continue blockingLoop;
         default:
-          print(`Undefined command: "${command}"`)
+          print(`Undefined command: "${command}". Try "help".`)
       }
     }
   }

--- a/python/pythonmonkey/lib/pmdb.py
+++ b/python/pythonmonkey/lib/pmdb.py
@@ -15,7 +15,7 @@ def debuggerInput(prompt: str):
     return ""
 
 def enable(debuggerGlobalObject = pm.eval("debuggerGlobal")):
-  debuggerGlobalObject.eval("""(debuggerInput, _pythonPrint) => {
+  debuggerGlobalObject.eval("""(debuggerInput, _pythonPrint, _pythonExit) => {
   const dbg = new Debugger()
   const mainDebuggee = dbg.addDebuggee(mainGlobal)
   dbg.uncaughtExceptionHook = (e) => {
@@ -99,7 +99,7 @@ def enable(debuggerGlobalObject = pm.eval("debuggerGlobal")):
         case "quit":
         case "kill":
           // Force exit the program
-          mainGlobal.python.exit(127)
+          _pythonExit(127)
           break blockingLoop;
         case "h":
         case "help":
@@ -140,4 +140,4 @@ def enable(debuggerGlobalObject = pm.eval("debuggerGlobal")):
   // Enter debugger on `debugger;` statement
   dbg.onDebuggerStatement = (frame) => enterDebuggerLoop(frame)
 
-  }""")(debuggerInput, print)
+  }""")(debuggerInput, print, lambda status: exit(int(status)))

--- a/python/pythonmonkey/lib/pmdb.py
+++ b/python/pythonmonkey/lib/pmdb.py
@@ -1,7 +1,8 @@
-# @file     pmdb - A gdb-like JavaScript debugger interface for pmjs
-#                  Enabled by `pmjs --inspect`
+# @file     pmdb - A gdb-like JavaScript debugger interface
 # @author   Tom Tang <xmader@distributive.network>
 # @date     July 2023
+
+import pythonmonkey as pm
 
 def debuggerInput(prompt: str):
   try:
@@ -13,7 +14,7 @@ def debuggerInput(prompt: str):
     print(e)
     return ""
 
-def pmdbEnable(debuggerGlobalObject):
+def enable(debuggerGlobalObject = pm.eval("debuggerGlobal")):
   debuggerGlobalObject.eval("""(debuggerInput, _pythonPrint) => {
   const dbg = new Debugger()
   const mainDebuggee = dbg.addDebuggee(mainGlobal)

--- a/python/pythonmonkey/lib/pmdb.py
+++ b/python/pythonmonkey/lib/pmdb.py
@@ -79,6 +79,7 @@ def enable(debuggerGlobalObject = pm.eval("debuggerGlobal")):
           const src = frame.script.source.text
           const line = src.split('\\n').slice(metadata.lineNumber-1, metadata.lineNumber).join('\\n')
           print(line)
+          print(" ".repeat(metadata.columnNumber) + "^") // indicate column position
           continue blockingLoop;
         }
         case "p":

--- a/src/JobQueue.cc
+++ b/src/JobQueue.cc
@@ -39,8 +39,7 @@ bool JobQueue::enqueuePromiseJob(JSContext *cx,
 }
 
 void JobQueue::runJobs(JSContext *cx) {
-  // TODO (Tom Tang):
-  throw std::logic_error("JobQueue::runJobs is not implemented.");
+  return;
 }
 
 // is empty
@@ -50,8 +49,8 @@ bool JobQueue::empty() const {
 }
 
 js::UniquePtr<JS::JobQueue::SavedJobQueue> JobQueue::saveJobQueue(JSContext *cx) {
-  // TODO (Tom Tang): implement this method way later
-  throw std::logic_error("JobQueue::saveJobQueue is not implemented\n");
+  auto saved = js::MakeUnique<JS::JobQueue::SavedJobQueue>();
+  return saved;
 }
 
 bool JobQueue::init(JSContext *cx) {

--- a/src/modules/pythonmonkey/pythonmonkey.cc
+++ b/src/modules/pythonmonkey/pythonmonkey.cc
@@ -431,6 +431,13 @@ PyMODINIT_FUNC PyInit_pythonmonkey(void)
     return NULL;
   }
 
+  JS::RootedObject debuggerGlobal(GLOBAL_CX, JS_NewGlobalObject(GLOBAL_CX, &globalClass, nullptr, JS::FireOnNewGlobalHook, options));
+  {
+    JSAutoRealm r(GLOBAL_CX, debuggerGlobal);
+    JS_DefineProperty(GLOBAL_CX, debuggerGlobal, "mainGlobal", *global, JSPROP_READONLY);
+    JS_DefineDebuggerObject(GLOBAL_CX, debuggerGlobal);
+  }
+
   autoRealm = new JSAutoRealm(GLOBAL_CX, *global);
 
   if (!JS_DefineFunctions(GLOBAL_CX, *global, jsGlobalFunctions)) {
@@ -439,14 +446,7 @@ PyMODINIT_FUNC PyInit_pythonmonkey(void)
   }
 
   JS_SetGCCallback(GLOBAL_CX, handleSharedPythonMonkeyMemory, NULL);
-
-  JS::RootedObject debuggerGlobal(GLOBAL_CX, JS_NewGlobalObject(GLOBAL_CX, &globalClass, nullptr, JS::FireOnNewGlobalHook, options));
-  {
-    JSAutoRealm r(GLOBAL_CX, debuggerGlobal);
-  }
-  JS_DefineProperty(GLOBAL_CX, *global, "debuggerGlobal", debuggerGlobal, JSPROP_ENUMERATE);
-
-  JS_DefineDebuggerObject(GLOBAL_CX, *global);
+  JS_DefineProperty(GLOBAL_CX, *global, "debuggerGlobal", debuggerGlobal, JSPROP_READONLY);
 
   // XXX: SpiderMonkey bug???
   // In https://hg.mozilla.org/releases/mozilla-esr102/file/3b574e1/js/src/jit/CacheIR.cpp#l317, trying to use the callback returned by `js::GetDOMProxyShadowsCheck()` even it's unset (nullptr)

--- a/src/modules/pythonmonkey/pythonmonkey.cc
+++ b/src/modules/pythonmonkey/pythonmonkey.cc
@@ -440,6 +440,14 @@ PyMODINIT_FUNC PyInit_pythonmonkey(void)
 
   JS_SetGCCallback(GLOBAL_CX, handleSharedPythonMonkeyMemory, NULL);
 
+  JS::RootedObject debuggerGlobal(GLOBAL_CX, JS_NewGlobalObject(GLOBAL_CX, &globalClass, nullptr, JS::FireOnNewGlobalHook, options));
+  {
+    JSAutoRealm r(GLOBAL_CX, debuggerGlobal);
+  }
+  JS_DefineProperty(GLOBAL_CX, *global, "debuggerGlobal", debuggerGlobal, JSPROP_ENUMERATE);
+
+  JS_DefineDebuggerObject(GLOBAL_CX, *global);
+
   // XXX: SpiderMonkey bug???
   // In https://hg.mozilla.org/releases/mozilla-esr102/file/3b574e1/js/src/jit/CacheIR.cpp#l317, trying to use the callback returned by `js::GetDOMProxyShadowsCheck()` even it's unset (nullptr)
   // Temporarily solved by explicitly setting the `domProxyShadowsCheck` callback here


### PR DESCRIPTION
Automatically enter the debugger on `debugger;` statements and uncaught exceptions

Supported commands:
- `b <lineNumber>`/`break <lineNumber>`: Set breakpoint on specific line
- `c`/`cont`: Continue execution until next breakpoint or `debugger` statement
- `n`/`next`: Step next
- `bt`/`backtrace`: Print backtrace of current execution frame
- `l`/`line`: Print current line
- `p <expr>`/`print <expr>`/`exec <expr>`: Execute an expression in debugging script's context and print its value
- `q`/`quit`/`kill`: Force exit the program
- `h`/`help`: Print help message

---

In pmjs, pmdb can be enabled by the `--inspect` flag
```bash
$ poetry run pmjs --inspect ddd.js
```
```js
// ddd.js
function abc() {
  let i = 0;
  let j = 1;
  debugger;
  i = 2; j = 2;
  i++
}
abc(1, 3, 5)
```

```console
(pmdb) > bt
abc@/home/xmader/github/Distributive-Network/PythonMonkey/ddd.js:3:3
@/home/xmader/github/Distributive-Network/PythonMonkey/ddd.js:7:4

(pmdb) > p arguments
{ '0': 1, '1': 3, '2': 5 }
(pmdb) > p a
1
(pmdb) > n
(pmdb) > bt
abc@/home/xmader/github/Distributive-Network/PythonMonkey/ddd.js:4:3
@/home/xmader/github/Distributive-Network/PythonMonkey/ddd.js:7:4

(pmdb) > l
  a = 2;
(pmdb) > n
(pmdb) > p a
2
(pmdb) > c
```

It can also be enabled in Python by calling `from pythonmonkey.lib import pmdb; pmdb.enable()`

```py
import pythonmonkey as pm
from pythonmonkey.lib import pmdb

pmdb.enable()

pm.eval("""
function abc(a, b) {
  debugger;
  a = 2;
  b++
}
abc(1, 3, 5)
""", {"filename": "ddd.js"})
```