### PR TITLE
Add actionable error message for no npm on system during pip install

### DIFF
--- a/python/pminit/post-install-hook.py
+++ b/python/pminit/post-install-hook.py
@@ -15,7 +15,7 @@ def execute(cmd: str):
         raise subprocess.CalledProcessError(return_code, cmd)
 
 def main():
-    node_package_manager = 'ynpm'
+    node_package_manager = 'npm'
     # check if npm is installed on the system
     if (shutil.which(node_package_manager) is None):
         print("""

--- a/python/pminit/post-install-hook.py
+++ b/python/pminit/post-install-hook.py
@@ -1,5 +1,6 @@
 import subprocess
 import sys
+import shutil
 
 def execute(cmd: str):
     popen = subprocess.Popen(cmd, stdout = subprocess.PIPE, stderr = subprocess.STDOUT,
@@ -14,7 +15,25 @@ def execute(cmd: str):
         raise subprocess.CalledProcessError(return_code, cmd)
 
 def main():
-    execute("cd pythonmonkey && npm i --no-package-lock") # do not update package-lock.json
+    node_package_manager = 'ynpm'
+    # check if npm is installed on the system
+    if (shutil.which(node_package_manager) is None):
+        print("""
+
+PythonMonkey Build Error:
+
+    
+  *    It appears npm is not installed on this system.
+  *    npm is required for PythonMonkey to build.
+  *    Please install NPM and Node.js before installing PythonMonkey.
+  *    Refer to the documentation for installing NPM and Node.js here: https://nodejs.org/en/download
+
+
+        """)
+        raise Exception("PythonMonkey build error: Unable to find npm on the system.")
+    else:
+        execute(f"cd pythonmonkey && {node_package_manager} i --no-package-lock") # do not update package-lock.json
 
 if __name__ == "__main__":
     main()
+


### PR DESCRIPTION
This change prints an error message during pip install when npm is not installed on the system:

The error should show up like this:
```
Building wheels for collected packages: pminit
  Building wheel for pminit (pyproject.toml) ... error
  error: subprocess-exited-with-error
  
  × Building wheel for pminit (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [38 lines of output]
      
      
      PythonMonkey Build Error:
      
      
        *    It appears npm is not installed on this system.
        *    npm is required for PythonMonkey to build.
        *    Please install NPM and Node.js before installing PythonMonkey.
        *    Refer to the documentation for installing NPM and Node.js here: https://nodejs.org/en/download
      
      
      
      Traceback (most recent call last):
        File "/tmp/pip-req-build-ryy_b0um/post-install-hook.py", line 38, in <module>
          main()
        File "/tmp/pip-req-build-ryy_b0um/post-install-hook.py", line 33, in main
          raise Exception("PythonMonkey build error: Unable to find npm on the system.")
      Exception: PythonMonkey build error: Unable to find npm on the system.
      Traceback (most recent call last):
        File "/home/will/.local/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
          main()
        File "/home/will/.local/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
        File "/home/will/.local/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 251, in build_wheel
          return _build_backend().build_wheel(wheel_directory, config_settings,
        File "/tmp/pip-build-env-m9x30o3s/overlay/local/lib/python3.10/dist-packages/poetry/core/masonry/api.py", line 57, in build_wheel
          return WheelBuilder.make_in(
        File "/tmp/pip-build-env-m9x30o3s/overlay/local/lib/python3.10/dist-packages/poetry/core/masonry/builders/wheel.py", line 88, in make_in
          wb.build(target_dir=directory)
        File "/tmp/pip-build-env-m9x30o3s/overlay/local/lib/python3.10/dist-packages/poetry/core/masonry/builders/wheel.py", line 123, in build
          self._build(zip_file)
        File "/tmp/pip-build-env-m9x30o3s/overlay/local/lib/python3.10/dist-packages/poetry/core/masonry/builders/wheel.py", line 172, in _build
          self._run_build_script(self._package.build_script)
        File "/tmp/pip-build-env-m9x30o3s/overlay/local/lib/python3.10/dist-packages/poetry/core/masonry/builders/wheel.py", line 232, in _run_build_script
          subprocess.check_call([self.executable.as_posix(), build_script])
        File "/usr/lib/python3.10/subprocess.py", line 369, in check_call
          raise CalledProcessError(retcode, cmd)
      subprocess.CalledProcessError: Command '['/usr/bin/python3', 'post-install-hook.py']' returned non-zero exit status 1.
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for pminit
Failed to build pminit
ERROR: Could not build wheels for pminit, which is required to install pyproject.toml-based projects
```

---

If there is a cleaner way to do this which results in less output, please let me know