### PR TITLE
fix: poetry-dynamic-versioning installation

### DIFF
--- a/.github/workflows/test-and-publish.yaml
+++ b/.github/workflows/test-and-publish.yaml
@@ -42,11 +42,6 @@ jobs:
             ./_spidermonkey_install/*
           key: spidermonkey115.1.0-${{ runner.os }}-${{ runner.arch }}
           lookup-only: true # skip download
-      - name: Setup Poetry
-        if: ${{ steps.cache-spidermonkey.outputs.cache-hit != 'true' }}
-        uses: snok/install-poetry@v1
-        with:
-          version: 1.5.1
       - name: Setup XCode
         if: ${{ matrix.os == 'macos-13' && steps.cache-spidermonkey.outputs.cache-hit != 'true' }}
         # SpiderMonkey 115 ESR requires XCode SDK version at least 13.3
@@ -67,11 +62,6 @@ jobs:
             ./_spidermonkey_install/*
           key: spidermonkey115.1.0-${{ runner.os }}-${{ runner.arch }}
           lookup-only: true # skip download
-      - name: Setup Poetry
-        if: ${{ steps.cache-spidermonkey.outputs.cache-hit != 'true' }}
-        uses: snok/install-poetry@v1
-        with:
-          version: 1.5.1
       - name: Install dependencies
         if: ${{ steps.cache-spidermonkey.outputs.cache-hit != 'true' }}
         shell: powershell

--- a/setup.sh
+++ b/setup.sh
@@ -24,6 +24,12 @@ fi
 curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.69 # force to use Rust 1.69 because 1.70 has linking issues on Windows
 # Setup Poetry
 curl -sSL https://install.python-poetry.org | python3 - --version "1.5.1"
+if [[ "$OSTYPE" == "msys"* ]]; then # Windows
+  POETRY_BIN="$APPDATA/Python/Scripts/poetry"
+else
+  POETRY_BIN=`echo ~/.local/bin/poetry` # expand tilde
+fi
+$POETRY_BIN self add 'poetry-dynamic-versioning[plugin]'
 echo "Done installing dependencies"
 
 echo "Downloading spidermonkey source code"

--- a/setup.sh
+++ b/setup.sh
@@ -24,7 +24,6 @@ fi
 curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.69 # force to use Rust 1.69 because 1.70 has linking issues on Windows
 # Setup Poetry
 curl -sSL https://install.python-poetry.org | python3 - --version "1.5.1"
-poetry self add "poetry-dynamic-versioning[plugin]"
 echo "Done installing dependencies"
 
 echo "Downloading spidermonkey source code"


### PR DESCRIPTION
`setup.sh` may fail on the first run because the `poetry` command may not available immediately after installation