### PR TITLE
fix(build.py): `git submodule update` fails when installing from source distribution (sdist)

### DIFF
--- a/build.py
+++ b/build.py
@@ -52,7 +52,6 @@ def copy_artifacts():
         execute("cp ./_spidermonkey_install/lib/libmozjs* ./python/pythonmonkey/", cwd=TOP_DIR)
 
 def build():
-    execute("git submodule update --init --recursive || echo 'Skipping. We are installing from an sdist tarball.'", cwd=TOP_DIR)
     ensure_spidermonkey()
     run_cmake_build()
     copy_artifacts()

--- a/build.py
+++ b/build.py
@@ -52,7 +52,7 @@ def copy_artifacts():
         execute("cp ./_spidermonkey_install/lib/libmozjs* ./python/pythonmonkey/", cwd=TOP_DIR)
 
 def build():
-    execute("git submodule update --init --recursive", cwd=TOP_DIR)
+    execute("git submodule update --init --recursive || echo 'Skipping. We are installing from an sdist tarball.'", cwd=TOP_DIR)
     ensure_spidermonkey()
     run_cmake_build()
     copy_artifacts()

--- a/tests/js/commonjs-modules.bash
+++ b/tests/js/commonjs-modules.bash
@@ -11,7 +11,11 @@ panic()
   echo "$*" >&2
   exit 2
 }
-cd `dirname "$0"`/../commonjs-official/tests/modules/1.0 || panic "could not change to test directory"
+
+cd `dirname "$0"`
+git submodule update --init --recursive || panic "could not checkout the required git submodule"
+
+cd ../commonjs-official/tests/modules/1.0 || panic "could not change to test directory"
 
 runTest()
 {


### PR DESCRIPTION
To test this, add `--no-binary pythonmonkey` flag to `pip install` to forcibly install from source code.