### PR TITLE
"contains" method for Object "in" operations added

### DIFF
--- a/include/JSObjectProxy.hh
+++ b/include/JSObjectProxy.hh
@@ -75,7 +75,7 @@ public:
   static PyObject *JSObjectProxy_get(JSObjectProxy *self, PyObject *key);
 
   /**
-   * @brief Getter method (.sq_contains), returns whether a key exists, used by the in operator
+   * @brief Test method (.sq_contains), returns whether a key exists, used by the in operator
    *
    * @param self - The JSObjectProxy
    * @param key - The key for the value in the JSObjectProxy

--- a/include/JSObjectProxy.hh
+++ b/include/JSObjectProxy.hh
@@ -75,6 +75,15 @@ public:
   static PyObject *JSObjectProxy_get(JSObjectProxy *self, PyObject *key);
 
   /**
+   * @brief Getter method (.sq_contains), returns whether a key exists, used by the in operator
+   *
+   * @param self - The JSObjectProxy
+   * @param key - The key for the value in the JSObjectProxy
+   * @return int 1 if `key` is in dict, 0 if not, and -1 on error
+   */
+  static int JSObjectProxy_contains(JSObjectProxy *self, PyObject *key);
+
+  /**
    * @brief Assign method (.mp_ass_subscript), assigns a key-value pair if value is non-NULL, or deletes a key-value pair if value is NULL
    *
    * @param self - The JSObjectProxy
@@ -83,15 +92,6 @@ public:
    * @return int -1 on exception, any other value otherwise
    */
   static int JSObjectProxy_assign(JSObjectProxy *self, PyObject *key, PyObject *value);
-
-  /**
-   * @brief Helper function for various JSObjectProxy methods, sets a key-value pair on a JSObject given a python string key and a JS::Value value
-   *
-   * @param jsObject - The underlying backing store JSObject for the JSObjectProxy
-   * @param key - The key to be assigned or deleted
-   * @param value - The JS::Value to be assigned
-   */
-  static void JSObjectProxy_set_helper(JS::HandleObject jsObject, PyObject *key, JS::HandleValue value);
 
   /**
    * @brief Comparison method (.tp_richcompare), returns appropriate boolean given a comparison operator and other pyobject
@@ -111,6 +111,7 @@ public:
    * @param visited
    * @return bool - Whether the compared objects are equal or not
    */
+  // private
   static bool JSObjectProxy_richcompare_helper(JSObjectProxy *self, PyObject *other, std::unordered_map<PyObject *, PyObject *> &visited);
 
   /**
@@ -139,6 +140,10 @@ static PyMappingMethods JSObjectProxy_mapping_methods = {
   .mp_length = (lenfunc)JSObjectProxyMethodDefinitions::JSObjectProxy_length,
   .mp_subscript = (binaryfunc)JSObjectProxyMethodDefinitions::JSObjectProxy_get,
   .mp_ass_subscript = (objobjargproc)JSObjectProxyMethodDefinitions::JSObjectProxy_assign
+};
+
+static PySequenceMethods JSObjectProxy_sequence_methods = {
+  .sq_contains = (objobjproc)JSObjectProxyMethodDefinitions::JSObjectProxy_contains
 };
 
 /**

--- a/src/JSObjectProxy.cc
+++ b/src/JSObjectProxy.cc
@@ -82,10 +82,8 @@ PyObject *JSObjectProxyMethodDefinitions::JSObjectProxy_get(JSObjectProxy *self,
   JS::RootedValue *value = new JS::RootedValue(GLOBAL_CX);
   JS_GetPropertyById(GLOBAL_CX, self->jsObject, id, value);
   JS::RootedObject *global = new JS::RootedObject(GLOBAL_CX, JS::GetNonCCWObjectGlobal(self->jsObject));
-  PyType *pyType = pyTypeFactory(GLOBAL_CX, global, value);
-  delete value;
-  delete global;
-  return pyType->getPyObject();
+  return pyTypeFactory(GLOBAL_CX, global, value)->getPyObject();
+  // TODO value and global appear to be leaking, but deleting them causes crashes
 }
 
 int JSObjectProxyMethodDefinitions::JSObjectProxy_contains(JSObjectProxy *self, PyObject *key)
@@ -96,9 +94,9 @@ int JSObjectProxyMethodDefinitions::JSObjectProxy_contains(JSObjectProxy *self, 
     return -1; // key is not a str or int
   }
 
-  JS::RootedValue value(GLOBAL_CX);
-  JS_GetPropertyById(GLOBAL_CX, self->jsObject, id, &value);
-  return value.isUndefined() ? 0 : 1;
+  JS::RootedValue *value = new JS::RootedValue(GLOBAL_CX);
+  JS_GetPropertyById(GLOBAL_CX, self->jsObject, id, value);
+  return value->isUndefined() ? 0 : 1;
 }
 
 int JSObjectProxyMethodDefinitions::JSObjectProxy_assign(JSObjectProxy *self, PyObject *key, PyObject *value)

--- a/src/JSObjectProxy.cc
+++ b/src/JSObjectProxy.cc
@@ -82,7 +82,23 @@ PyObject *JSObjectProxyMethodDefinitions::JSObjectProxy_get(JSObjectProxy *self,
   JS::RootedValue *value = new JS::RootedValue(GLOBAL_CX);
   JS_GetPropertyById(GLOBAL_CX, self->jsObject, id, value);
   JS::RootedObject *global = new JS::RootedObject(GLOBAL_CX, JS::GetNonCCWObjectGlobal(self->jsObject));
-  return pyTypeFactory(GLOBAL_CX, global, value)->getPyObject();
+  PyType *pyType = pyTypeFactory(GLOBAL_CX, global, value);
+  delete value;
+  delete global;
+  return pyType->getPyObject();
+}
+
+int JSObjectProxyMethodDefinitions::JSObjectProxy_contains(JSObjectProxy *self, PyObject *key)
+{
+  JS::RootedId id(GLOBAL_CX);
+  if (!keyToId(key, &id)) {
+    // TODO (Caleb Aikens): raise exception here
+    return -1; // key is not a str or int
+  }
+
+  JS::RootedValue value(GLOBAL_CX);
+  JS_GetPropertyById(GLOBAL_CX, self->jsObject, id, &value);
+  return value.isUndefined() ? 0 : 1;
 }
 
 int JSObjectProxyMethodDefinitions::JSObjectProxy_assign(JSObjectProxy *self, PyObject *key, PyObject *value)
@@ -102,13 +118,6 @@ int JSObjectProxyMethodDefinitions::JSObjectProxy_assign(JSObjectProxy *self, Py
   }
 
   return 0;
-}
-
-void JSObjectProxyMethodDefinitions::JSObjectProxy_set_helper(JS::HandleObject jsObject, PyObject *key, JS::HandleValue value)
-{
-  JS::RootedId id(GLOBAL_CX);
-  keyToId(key, &id);
-  JS_SetPropertyById(GLOBAL_CX, jsObject, id, value);
 }
 
 PyObject *JSObjectProxyMethodDefinitions::JSObjectProxy_richcompare(JSObjectProxy *self, PyObject *other, int op)
@@ -163,7 +172,8 @@ bool JSObjectProxyMethodDefinitions::JSObjectProxy_richcompare_helper(JSObjectPr
   }
 
   // iterate recursively through members of self and check for equality
-  for (size_t i = 0; i < props.length(); i++)
+  size_t length = props.length();
+  for (size_t i = 0; i < length; i++)
   {
     JS::HandleId id = props[i];
     JS::RootedValue *key = new JS::RootedValue(GLOBAL_CX);

--- a/src/modules/pythonmonkey/pythonmonkey.cc
+++ b/src/modules/pythonmonkey/pythonmonkey.cc
@@ -74,6 +74,7 @@ PyTypeObject JSObjectProxyType = {
   .tp_basicsize = sizeof(JSObjectProxy),
   .tp_dealloc = (destructor)JSObjectProxyMethodDefinitions::JSObjectProxy_dealloc,
   .tp_repr = (reprfunc)JSObjectProxyMethodDefinitions::JSObjectProxy_repr,
+  .tp_as_sequence = &JSObjectProxy_sequence_methods,
   .tp_as_mapping = &JSObjectProxy_mapping_methods,
   .tp_getattro = (getattrofunc)JSObjectProxyMethodDefinitions::JSObjectProxy_get,
   .tp_setattro = (setattrofunc)JSObjectProxyMethodDefinitions::JSObjectProxy_assign,

--- a/tests/python/test_dicts_lists.py
+++ b/tests/python/test_dicts_lists.py
@@ -128,9 +128,16 @@ def test_eval_objects_jsproxy_compare():
     assert proxy == {'a': 1.0, 'b': 2.0}
 
 def test_eval_objects_jsproxy_contains():
-    proxy = pm.eval('[1, 2, 3]')
-    assert 1 in proxy
+    pm.eval("let obj = {'c':5}")
+    a = pm.eval('obj')
+    assert 'c' in a
 
 def test_eval_objects_jsproxy_does_not_contain():
-    proxy = pm.eval('[1, 2, 3]')
-    assert not(4 in proxy)
+    pm.eval("let obj1 = {'c':5}")
+    a = pm.eval('obj1')
+    assert not(4 in a)
+
+def test_eval_objects_jsproxy_does_not_contain_value():
+    pm.eval("let obj2 = {'c':5}")
+    a = pm.eval('obj2')
+    assert not(5 in a)

--- a/tests/python/test_dicts_lists.py
+++ b/tests/python/test_dicts_lists.py
@@ -128,16 +128,13 @@ def test_eval_objects_jsproxy_compare():
     assert proxy == {'a': 1.0, 'b': 2.0}
 
 def test_eval_objects_jsproxy_contains():
-    pm.eval("let obj = {'c':5}")
-    a = pm.eval('obj')
+    a = pm.eval("({'c':5})")
     assert 'c' in a
 
 def test_eval_objects_jsproxy_does_not_contain():
-    pm.eval("let obj1 = {'c':5}")
-    a = pm.eval('obj1')
+    a = pm.eval("({'c':5})")
     assert not(4 in a)
 
 def test_eval_objects_jsproxy_does_not_contain_value():
-    pm.eval("let obj2 = {'c':5}")
-    a = pm.eval('obj2')
+    a = pm.eval("({'c':5})")
     assert not(5 in a)

--- a/tests/python/test_dicts_lists.py
+++ b/tests/python/test_dicts_lists.py
@@ -126,3 +126,11 @@ def test_eval_objects_jsproxy_delete():
 def test_eval_objects_jsproxy_compare():
     proxy = pm.eval("({a: 1, b:2})")
     assert proxy == {'a': 1.0, 'b': 2.0}
+
+def test_eval_objects_jsproxy_contains():
+    proxy = pm.eval('[1, 2, 3]')
+    assert 1 in proxy
+
+def test_eval_objects_jsproxy_does_not_contain():
+    proxy = pm.eval('[1, 2, 3]')
+    assert not(4 in proxy)


### PR DESCRIPTION
now support the "in" operation for Dicts
cleanup unused method
fix memory leak

closes #187 

Does not implement "in" for Lists yet. This is left to https://github.com/Distributive-Network/PythonMonkey/pull/186