### PR TITLE
Note that Git is Required to Install PythonMonkey

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ For VSCode users, similar to the Build Task, we have a Test Task ready to use.
 
 ## Using the library
 
-> npm (Node.js) is required **during installation only** to populate the JS dependencies.
+> npm (Node.js) and git are required **during installation only** to populate the JS dependencies.
 
 ### Install from [PyPI](https://pypi.org/project/pythonmonkey/)
 


### PR DESCRIPTION
git is now required during pip install, otherwise this error will appear:
```
  × Building wheel for pythonmonkey (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [29 lines of output]
      /bin/sh: 1: git: not found
```