### PR TITLE
Make NPM Error Stand Out With Emojis 🤨 😲

### DIFF
--- a/python/pminit/post-install-hook.py
+++ b/python/pminit/post-install-hook.py
@@ -19,9 +19,11 @@ def main():
     # check if npm is installed on the system
     if (shutil.which(node_package_manager) is None):
         print("""
+⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️
 
-PythonMonkey Build Error:
 
+
+🐍🐒 PythonMonkey Build Error:
     
   *    It appears npm is not installed on this system.
   *    npm is required for PythonMonkey to build.
@@ -29,6 +31,7 @@ PythonMonkey Build Error:
   *    Refer to the documentation for installing NPM and Node.js here: https://nodejs.org/en/download
 
 
+⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️
         """)
         raise Exception("PythonMonkey build error: Unable to find npm on the system.")
     else:


### PR DESCRIPTION
# Adding Emojis to the _No NPM Build Error Message_

This PR adds some emojis to a build error to make it stand out more.

## But Why?: Context
The other day, someone submitted an issue to PythonMonkey reporting a failed build from `pip install pythonmonkey`. Check out the ticket here https://github.com/Distributive-Network/PythonMonkey/issues/213

As part of the issue, the user helpfully appended the error output from the attempted pip install. I'll copy and paste it below:
```
Collecting pythonmonkey
  Using cached pythonmonkey-0.2.3-cp310-cp310-win_amd64.whl (9.9 MB)
Collecting pyreadline3<4.0.0,>=3.4.1
  Using cached pyreadline3-3.4.1-py3-none-any.whl (95 kB)
Collecting pminit
  Using cached pminit-0.2.3.tar.gz (7.2 kB)
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Requirement already satisfied: aiohttp[speedups]<4.0.0,>=3.9.0b1 in c:\users\user\appdata\local\programs\python\python310\lib\site-packages (from pythonmonkey) (3.9.1)
Requirement already satisfied: frozenlist>=1.1.1 in c:\users\user\appdata\local\programs\python\python310\lib\site-packages (from aiohttp[speedups]<4.0.0,>=3.9.0b1->pythonmonkey) (1.4.1)
Requirement already satisfied: yarl<2.0,>=1.0 in c:\users\user\appdata\local\programs\python\python310\lib\site-packages (from aiohttp[speedups]<4.0.0,>=3.9.0b1->pythonmonkey) (1.9.4)
Requirement already satisfied: async-timeout<5.0,>=4.0 in c:\users\user\appdata\local\programs\python\python310\lib\site-packages (from aiohttp[speedups]<4.0.0,>=3.9.0b1->pythonmonkey) (4.0.3)
Requirement already satisfied: aiosignal>=1.1.2 in c:\users\user\appdata\local\programs\python\python310\lib\site-packages (from aiohttp[speedups]<4.0.0,>=3.9.0b1->pythonmonkey) (1.3.1)
Requirement already satisfied: multidict<7.0,>=4.5 in c:\users\user\appdata\local\programs\python\python310\lib\site-packages (from aiohttp[speedups]<4.0.0,>=3.9.0b1->pythonmonkey) (6.0.4)
Requirement already satisfied: attrs>=17.3.0 in c:\users\user\appdata\local\programs\python\python310\lib\site-packages (from aiohttp[speedups]<4.0.0,>=3.9.0b1->pythonmonkey) (23.2.0)
Collecting Brotli
  Using cached Brotli-1.1.0-cp310-cp310-win_amd64.whl (357 kB)
Requirement already satisfied: idna>=2.0 in c:\users\user\appdata\local\programs\python\python310\lib\site-packages (from yarl<2.0,>=1.0->aiohttp[speedups]<4.0.0,>=3.9.0b1->pythonmonkey) (3.6)
Building wheels for collected packages: pminit
  Building wheel for pminit (pyproject.toml) ... error
  error: subprocess-exited-with-error

  × Building wheel for pminit (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [38 lines of output]


      PythonMonkey Build Error:


        *    It appears npm is not installed on this system.
        *    npm is required for PythonMonkey to build.
        *    Please install NPM and Node.js before installing PythonMonkey.
        *    Refer to the documentation for installing NPM and Node.js here: https://nodejs.org/en/download



      Traceback (most recent call last):
        File "C:\Users\User\AppData\Local\Temp\pip-install-exztcswz\pminit_b25df74e94a342b69f5987bf172c0328\post-install-hook.py", line 38, in <module>
          main()
        File "C:\Users\User\AppData\Local\Temp\pip-install-exztcswz\pminit_b25df74e94a342b69f5987bf172c0328\post-install-hook.py", line 33, in main
          raise Exception("PythonMonkey build error: Unable to find npm on the system.")
      Exception: PythonMonkey build error: Unable to find npm on the system.
      Traceback (most recent call last):
        File "C:\Users\User\AppData\Local\Programs\Python\Python310\lib\site-packages\pip\_vendor\pep517\in_process\_in_process.py", line 363, in <module>
          main()
        File "C:\Users\User\AppData\Local\Programs\Python\Python310\lib\site-packages\pip\_vendor\pep517\in_process\_in_process.py", line 345, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
        File "C:\Users\User\AppData\Local\Programs\Python\Python310\lib\site-packages\pip\_vendor\pep517\in_process\_in_process.py", line 261, in build_wheel
          return _build_backend().build_wheel(wheel_directory, config_settings,
        File "C:\Users\User\AppData\Local\Temp\pip-build-env-8hgmxpve\overlay\Lib\site-packages\poetry\core\masonry\api.py", line 58, in build_wheel
          return WheelBuilder.make_in(
        File "C:\Users\User\AppData\Local\Temp\pip-build-env-8hgmxpve\overlay\Lib\site-packages\poetry\core\masonry\builders\wheel.py", line 88, in make_in
          wb.build(target_dir=directory)
        File "C:\Users\User\AppData\Local\Temp\pip-build-env-8hgmxpve\overlay\Lib\site-packages\poetry\core\masonry\builders\wheel.py", line 123, in build
          self._build(zip_file)
        File "C:\Users\User\AppData\Local\Temp\pip-build-env-8hgmxpve\overlay\Lib\site-packages\poetry\core\masonry\builders\wheel.py", line 172, in _build
          self._run_build_script(self._package.build_script)
        File "C:\Users\User\AppData\Local\Temp\pip-build-env-8hgmxpve\overlay\Lib\site-packages\poetry\core\masonry\builders\wheel.py", line 266, in _run_build_script
          subprocess.check_call([self.executable.as_posix(), build_script])
        File "C:\Users\User\AppData\Local\Programs\Python\Python310\lib\subprocess.py", line 369, in check_call
          raise CalledProcessError(retcode, cmd)
      subprocess.CalledProcessError: Command '['C:/Users/User/AppData/Local/Programs/Python/Python310/python.exe', 'post-install-hook.py']' returned non-zero exit status 1.
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for pminit
Failed to build pminit
ERROR: Could not build wheels for pminit, which is required to install pyproject.toml-based projects
```

Hmm, that's a lot of text! As a PythonMonkey developer, you were probably able to see the error message easily enough and note the explanation of the error, why NPM is required during pip install, and the actionable steps to install it `Please install NPM and Node.js before installing PythonMonkey` - but as a user, I think it's pretty easy to miss just like how the user who submitted the issue missed it. I would also make the assumption that the type of user to submit an issue on GitHub, is probably more savvy than the typical user. Anecdotally, when I have a build issue, submitting an issue to the maintainers is a last resort. So if this user reported this issue, I'd bet many many more encountered this issue, weren't able to see the actionable steps, and gave up. 

## Emojis
When I see big walls of text, be it in a console or even something like a linkedin post, but especially when nested in other long pieces of text which I am trained to ignore 99% of the time, it just blends in. I think spacing can help set it apart, but even still, if you blur your eyes a little, you can't pinpoint the error message above. 

I think adding some emojis tastefully and sparingly can help make these errors stand out more. I also think, an emoji in an error message would pique my curiosity and make me want to read it.

An overuse of emojis would result in the same problem as before since your brain would just start to see them as part of the noise.

### Is it professional to put emojis in error messages?
Who cares! But, for what it's worth, it is common for modern cli programs to include emojis - specifically in the Python ecosystem. One fun example is the [Mojo programming language, which is _a_ Python, that uses (.🔥 or .mojo) as the file extension](https://docs.modular.com/mojo/faq.html). I think its also fun branding to add the "Python" and "Monkey" emojis. 

### How do Emojis Render in different environments where one may read a PythonMonkey build error
The biggest argument against using emojis in error messages is that the environments where a user may read emojis from differs significantly, and emoji rendering is not standardized. 

### Example
#### VSCODE ([In 2023, 73% of Developers report using VS Code](https://survey.stackoverflow.co/2023/))
![image](https://github.com/Distributive-Network/PythonMonkey/assets/18359452/246b4aeb-c777-4c14-9399-93194cc1358f)

#### Gnome-Terminal (commonly used modern terminal emulator) (top) & RXVT-Unicode (older terminal emulator) (bottom)
![Screenshot from 2024-01-20 10-35-16](https://github.com/Distributive-Network/PythonMonkey/assets/18359452/78e505b2-7cd7-4075-854e-d06be41a691a)

Despite each environment displaying emojis differently, I feel like the addition of Emojis makes this error message stand out more. 
