### PR TITLE
ci: fix MozillaBuild

### DIFF
--- a/.github/workflows/test-and-publish.yaml
+++ b/.github/workflows/test-and-publish.yaml
@@ -77,6 +77,10 @@ jobs:
           powershell -command 'Start-Process -Wait -FilePath "./MozillaBuildSetup-Latest.exe" -ArgumentList "/S"'
       - name: Build spidermonkey in MozillaBuild environment
         if: ${{ steps.cache-spidermonkey.outputs.cache-hit != 'true' }}
+        env:
+          # Preserve MozillaBuild v4.0.x behaviour
+          # see https://groups.google.com/u/1/a/mozilla.org/g/dev-platform/c/hF51Q3j6ca8
+          USE_MINTTY: 0
         run: /c/mozilla-build/start-shell.bat -use-full-path -here ./setup.sh
   build-and-test:
     needs: [build-spidermonkey-unix, build-spidermonkey-win]


### PR DESCRIPTION
We currently always install the latest MozillaBuild version from https://ftp.mozilla.org/pub/mozilla/libraries/win32/MozillaBuildSetup-Latest.exe. 
On [11-Jan-2024](https://ftp.mozilla.org/pub/mozilla/libraries/win32/), MozillaBuild version 4.1 was [released](https://groups.google.com/u/1/a/mozilla.org/g/dev-platform/c/hF51Q3j6ca8), and it contained some [behaviour changes](https://bugzilla.mozilla.org/show_bug.cgi?id=1869958) that we didn't know. 

This PR adds an env var to preserve MozillaBuild v4.0.x behaviour.

See https://groups.google.com/u/1/a/mozilla.org/g/dev-platform/c/hF51Q3j6ca8,
also https://bugzilla.mozilla.org/show_bug.cgi?id=1869958