### PR TITLE
Fix Socket.IO connection timeout

### DIFF
--- a/python/pythonmonkey/builtin_modules/XMLHttpRequest.js
+++ b/python/pythonmonkey/builtin_modules/XMLHttpRequest.js
@@ -176,13 +176,27 @@ class XMLHttpRequest extends XMLHttpRequestEventTarget
    */
   timeout = 0;
 
+  /**
+   * A boolean value that indicates whether or not cross-site `Access-Control` requests should be made using credentials such as cookies, authorization headers or TLS client certificates.  
+   * Setting withCredentials has no effect on same-origin requests.
+   * @see https://xhr.spec.whatwg.org/#the-withcredentials-attribute
+   */
   get withCredentials()
   {
-    return false;
+    return this.#crossOriginCredentials;
   }
   set withCredentials(flag)
   {
-    // do nothing
+    // step 1
+    if (this.#state !== XMLHttpRequest.UNSENT && this.#state !== XMLHttpRequest.OPENED)
+      // The XHR internal state should be UNSENT or OPENED.
+      throw new DOMException('XMLHttpRequest must not be sending.', 'InvalidStateError');
+    // step 2
+    if (this.#sendFlag)
+      throw new DOMException('send() has already been called', 'InvalidStateError');
+    // step 3
+    this.#crossOriginCredentials = flag;
+    // TODO: figure out what cross-origin means in PythonMonkey. Is it always same-origin request? What to send?
   }
 
   /**
@@ -565,6 +579,7 @@ class XMLHttpRequest extends XMLHttpRequestEventTarget
   #uploadObject = new XMLHttpRequestUpload();
   #state = XMLHttpRequest.UNSENT; // One of unsent, opened, headers received, loading, and done; initially unsent.
   #sendFlag = false; // A flag, initially unset.
+  #crossOriginCredentials = false; // A boolean, initially false.
   /** @type {Method} */
   #requestMethod = null;
   /** @type {URL} */

--- a/python/pythonmonkey/builtin_modules/XMLHttpRequest.js
+++ b/python/pythonmonkey/builtin_modules/XMLHttpRequest.js
@@ -182,7 +182,7 @@ class XMLHttpRequest extends XMLHttpRequestEventTarget
   }
   set withCredentials(flag)
   {
-    throw new DOMException('xhr.withCredentials is not supported in PythonMonkey.', 'InvalidAccessError');
+    // do nothing
   }
 
   /**

--- a/python/pythonmonkey/builtin_modules/timers.js
+++ b/python/pythonmonkey/builtin_modules/timers.js
@@ -53,6 +53,10 @@ function setTimeout(handler, delayMs = 0, ...args)
  */
 function clearTimeout(timeoutId) 
 {
+  // silently does nothing when an invalid timeoutId (should be an int32 value) is passed in
+  if (!Number.isInteger(timeoutId))
+    return;
+
   return cancelByTimeoutId(timeoutId);
 }
 

--- a/src/internalBinding/timers.cc
+++ b/src/internalBinding/timers.cc
@@ -44,13 +44,13 @@ static bool cancelByTimeoutId(JSContext *cx, unsigned argc, JS::Value *vp) {
 
   args.rval().setUndefined();
 
-  // silently does nothing when an invalid timeoutID is passed in
-  if (!timeoutIdArg.isInt32()) {
+  // silently does nothing when an invalid timeoutID (should be an int32 value) is passed in
+  if (!timeoutIdArg.isNumber()) {
     return true;
   }
 
   // Retrieve the AsyncHandle by `timeoutID`
-  int32_t timeoutID = timeoutIdArg.toInt32();
+  double timeoutID = timeoutIdArg.toNumber();
   AsyncHandle *handle = AsyncHandle::fromId((uint32_t)timeoutID);
   if (!handle) return true; // does nothing on invalid timeoutID
 

--- a/src/internalBinding/timers.cc
+++ b/src/internalBinding/timers.cc
@@ -32,7 +32,7 @@ static bool enqueueWithDelay(JSContext *cx, unsigned argc, JS::Value *vp) {
   PyEventLoop::AsyncHandle handle = loop.enqueueWithDelay(job, delaySeconds);
 
   // Return the `timeoutID` to use in `clearTimeout`
-  args.rval().setDouble((double)PyEventLoop::AsyncHandle::getUniqueId(std::move(handle)));
+  args.rval().setNumber(PyEventLoop::AsyncHandle::getUniqueId(std::move(handle)));
   return true;
 }
 

--- a/src/internalBinding/timers.cc
+++ b/src/internalBinding/timers.cc
@@ -36,21 +36,14 @@ static bool enqueueWithDelay(JSContext *cx, unsigned argc, JS::Value *vp) {
   return true;
 }
 
-// TODO (Tom Tang): move argument checks to the JavaScript side
 static bool cancelByTimeoutId(JSContext *cx, unsigned argc, JS::Value *vp) {
   using AsyncHandle = PyEventLoop::AsyncHandle;
   JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
-  JS::HandleValue timeoutIdArg = args.get(0);
+  double timeoutID = args.get(0).toNumber();
 
   args.rval().setUndefined();
 
-  // silently does nothing when an invalid timeoutID (should be an int32 value) is passed in
-  if (!timeoutIdArg.isNumber()) {
-    return true;
-  }
-
   // Retrieve the AsyncHandle by `timeoutID`
-  double timeoutID = timeoutIdArg.toNumber();
   AsyncHandle *handle = AsyncHandle::fromId((uint32_t)timeoutID);
   if (!handle) return true; // does nothing on invalid timeoutID
 

--- a/tests/python/test_event_loop.py
+++ b/tests/python/test_event_loop.py
@@ -37,8 +37,16 @@ def test_set_clear_timeout():
         # `setTimeout` should allow passing additional arguments to the callback, as spec-ed
         assert 3.0 == await pm.eval("new Promise((resolve) => setTimeout(function(){ resolve(arguments.length) }, 100, 90, 91, 92))")
         assert 92.0 == await pm.eval("new Promise((resolve) => setTimeout((...args) => { resolve(args[2]) }, 100, 90, 91, 92))")
-        # TODO (Tom Tang): test `setTimeout` setting delay to 0 if < 0
-        # TODO (Tom Tang): test `setTimeout` accepting string as the delay, coercing to a number like parseFloat
+        # test `setTimeout` setting delay to 0 if < 0
+        await asyncio.wait_for(pm.eval("new Promise((resolve) => setTimeout(resolve, 0))"), timeout=0.02)
+        await asyncio.wait_for(pm.eval("new Promise((resolve) => setTimeout(resolve, -10000))"), timeout=0.02) # won't be precisely 0s
+        # test `setTimeout` accepting string as the delay, coercing to a number.
+        # Number('100') -> 100, pass if the actual delay is > 90ms and < 120ms
+        await asyncio.wait_for(pm.eval("new Promise((resolve) => setTimeout(resolve, '100'))"), timeout=0.12) # won't be precisely 100ms
+        with pytest.raises(asyncio.exceptions.TimeoutError):
+            await asyncio.wait_for(pm.eval("new Promise((resolve) => setTimeout(resolve, '100'))"), timeout=0.09)
+        # Number("1 second") -> NaN -> delay turns to be 0s
+        await asyncio.wait_for(pm.eval("new Promise((resolve) => setTimeout(resolve, '1 second'))"), timeout=0.02) # won't be precisely 0s
 
         # passing an invalid ID to `clearTimeout` should silently do nothing; no exception is thrown.
         pm.eval("clearTimeout(NaN)")

--- a/tests/python/test_event_loop.py
+++ b/tests/python/test_event_loop.py
@@ -38,15 +38,15 @@ def test_set_clear_timeout():
         assert 3.0 == await pm.eval("new Promise((resolve) => setTimeout(function(){ resolve(arguments.length) }, 100, 90, 91, 92))")
         assert 92.0 == await pm.eval("new Promise((resolve) => setTimeout((...args) => { resolve(args[2]) }, 100, 90, 91, 92))")
         # test `setTimeout` setting delay to 0 if < 0
-        await asyncio.wait_for(pm.eval("new Promise((resolve) => setTimeout(resolve, 0))"), timeout=0.02)
-        await asyncio.wait_for(pm.eval("new Promise((resolve) => setTimeout(resolve, -10000))"), timeout=0.02) # won't be precisely 0s
+        await asyncio.wait_for(pm.eval("new Promise((resolve) => setTimeout(resolve, 0))"), timeout=0.05)
+        await asyncio.wait_for(pm.eval("new Promise((resolve) => setTimeout(resolve, -10000))"), timeout=0.05) # won't be precisely 0s
         # test `setTimeout` accepting string as the delay, coercing to a number.
-        # Number('100') -> 100, pass if the actual delay is > 90ms and < 120ms
-        await asyncio.wait_for(pm.eval("new Promise((resolve) => setTimeout(resolve, '100'))"), timeout=0.12) # won't be precisely 100ms
+        # Number('100') -> 100, pass if the actual delay is > 90ms and < 150ms
+        await asyncio.wait_for(pm.eval("new Promise((resolve) => setTimeout(resolve, '100'))"), timeout=0.15) # won't be precisely 100ms
         with pytest.raises(asyncio.exceptions.TimeoutError):
             await asyncio.wait_for(pm.eval("new Promise((resolve) => setTimeout(resolve, '100'))"), timeout=0.09)
         # Number("1 second") -> NaN -> delay turns to be 0s
-        await asyncio.wait_for(pm.eval("new Promise((resolve) => setTimeout(resolve, '1 second'))"), timeout=0.02) # won't be precisely 0s
+        await asyncio.wait_for(pm.eval("new Promise((resolve) => setTimeout(resolve, '1 second'))"), timeout=0.05) # won't be precisely 0s
 
         # passing an invalid ID to `clearTimeout` should silently do nothing; no exception is thrown.
         pm.eval("clearTimeout(NaN)")


### PR DESCRIPTION
This PR fixes the following issues:

* In XMLHttpRequest, previously we throw a `DOMException(InvalidAccessError)` when trying to access the `xhr.withCredentials` getter/setter. However in socket.io-client, it tries to set `xhr.withCredentials` but cannot catch the exception, thus breaks the connection.

* In our `clearTimeout` API, previously we expects the [`timeoutId` argument](https://developer.mozilla.org/en-US/docs/Web/API/clearTimeout#parameters) is stored as an int32 value internally (JS numbers are always float64 values **in JS context** but mostly they are optimized **internally**). However in practice, JS number is not always optimized to an int32 value even though it's integral. 
In socket.io, old timers for the connection `timeout` don't get cancelled properly because the `timeoutId` seen as invalid, so the connection is closed prematurely.

* [`xhr.responseType`](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/responseType) can be one of `"" | "arraybuffer" | "blob" | "document" | "json" | "text"`. We implemented `"text"` and `"arraybuffer"`, but `"json"` is missing, which socket.io also requires. 
`"blob"` or `"document"` are still TODOs because there's no point outside of browser environment.

---

This PR would close https://github.com/Distributive-Network/PythonMonkey/issues/232.