### PR TITLE
CI: use GitHub hosted runners to build for arm64 macOS

### DIFF
--- a/.github/workflows/test-and-publish.yaml
+++ b/.github/workflows/test-and-publish.yaml
@@ -25,8 +25,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Use Ubuntu 20.04 / macOS 13 + Python 3.10 to build SpiderMonkey
-        os: [ 'ubuntu-20.04', 'macos-13', 'm2ci' ]
+        # Use Ubuntu 20.04 / macOS 13 x86_64 / macOS 14 arm64 + Python 3.10 to build SpiderMonkey
+        os: [ 'ubuntu-20.04', 'macos-13', 'macos-14-arm64' ]
         python_version: [ '3.10' ]
     runs-on: ${{ matrix.os }}
     steps:
@@ -88,7 +88,7 @@ jobs:
       fail-fast: false
       matrix:
         # The lowest supported version is Ubuntu 20.04 + Python 3.8 or macOS 12 + Python 3.9
-        os: [ 'ubuntu-20.04', 'macos-12', 'windows-2019', 'm2ci' ]
+        os: [ 'ubuntu-20.04', 'macos-12', 'windows-2019', 'macos-14-arm64' ]
         python_version: [ '3.8', '3.9', '3.10', '3.11', '3.12' ]
         exclude:
           # macOS 12 comes with Python 3.9 by default, so we drop ci support for Python 3.8 on macOS
@@ -97,9 +97,9 @@ jobs:
             python_version: '3.8'
           # actions/setup-python: The version '3.8'/'3.9' with architecture 'arm64' was not found for macOS.
           # see https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
-          - os: 'm2ci'
+          - os: 'macos-14-arm64'
             python_version: '3.8'
-          - os: 'm2ci'
+          - os: 'macos-14-arm64'
             python_version: '3.9'
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test-and-publish.yaml
+++ b/.github/workflows/test-and-publish.yaml
@@ -44,7 +44,7 @@ jobs:
           key: spidermonkey115.7.0-${{ runner.os }}-${{ runner.arch }}
           lookup-only: true # skip download
       - name: Setup XCode
-        if: ${{ matrix.os == 'macos-13' && steps.cache-spidermonkey.outputs.cache-hit != 'true' }}
+        if: ${{ (matrix.os == 'macos-13' || matrix.os == 'macos-14') && steps.cache-spidermonkey.outputs.cache-hit != 'true' }}
         # SpiderMonkey 115 ESR requires XCode SDK version at least 13.3
         # https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md#installed-sdks
         run: sudo xcode-select -switch /Applications/Xcode_14.3.app

--- a/.github/workflows/test-and-publish.yaml
+++ b/.github/workflows/test-and-publish.yaml
@@ -26,7 +26,8 @@ jobs:
       fail-fast: false
       matrix:
         # Use Ubuntu 20.04 / macOS 13 x86_64 / macOS 14 arm64 + Python 3.10 to build SpiderMonkey
-        os: [ 'ubuntu-20.04', 'macos-13', 'macos-14-arm64' ]
+        os: [ 'ubuntu-20.04', 'macos-13', 'macos-14' ] # macOS 14 runner exclusively runs on M1 hardwares
+                                                       # see https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available
         python_version: [ '3.10' ]
     runs-on: ${{ matrix.os }}
     steps:
@@ -88,7 +89,7 @@ jobs:
       fail-fast: false
       matrix:
         # The lowest supported version is Ubuntu 20.04 + Python 3.8 or macOS 12 + Python 3.9
-        os: [ 'ubuntu-20.04', 'macos-12', 'windows-2019', 'macos-14-arm64' ]
+        os: [ 'ubuntu-20.04', 'macos-12', 'windows-2019', 'macos-14' ]
         python_version: [ '3.8', '3.9', '3.10', '3.11', '3.12' ]
         exclude:
           # macOS 12 comes with Python 3.9 by default, so we drop ci support for Python 3.8 on macOS
@@ -97,9 +98,9 @@ jobs:
             python_version: '3.8'
           # actions/setup-python: The version '3.8'/'3.9' with architecture 'arm64' was not found for macOS.
           # see https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
-          - os: 'macos-14-arm64'
+          - os: 'macos-14'
             python_version: '3.8'
-          - os: 'macos-14-arm64'
+          - os: 'macos-14'
             python_version: '3.9'
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Instead of using our own m2 machine in the office,
move to the GitHub hosted workers as they have apple silicon (m1) runners now.
https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/