### PR TITLE
Hotfix: Loosen tests timeout

### DIFF
--- a/tests/python/test_event_loop.py
+++ b/tests/python/test_event_loop.py
@@ -46,7 +46,7 @@ def test_set_clear_timeout():
         with pytest.raises(asyncio.exceptions.TimeoutError):
             await asyncio.wait_for(pm.eval("new Promise((resolve) => setTimeout(resolve, '100'))"), timeout=0.09)
         # Number("1 second") -> NaN -> delay turns to be 0s
-        await asyncio.wait_for(pm.eval("new Promise((resolve) => setTimeout(resolve, '1 second'))"), timeout=0.05) # won't be precisely 0s
+        await asyncio.wait_for(pm.eval("new Promise((resolve) => setTimeout(resolve, '1 second'))"), timeout=0.5) # won't be precisely 0s
 
         # passing an invalid ID to `clearTimeout` should silently do nothing; no exception is thrown.
         pm.eval("clearTimeout(NaN)")


### PR DESCRIPTION
The test for https://github.com/Distributive-Network/PythonMonkey/blob/59b2fadf6eccd0439ec38946cb7fd045cd5d491e/tests/python/test_event_loop.py#L49 [initially succeeded](https://github.com/Distributive-Network/PythonMonkey/actions/runs/7932630581/job/21661171813) but sometimes [fails](https://github.com/Distributive-Network/PythonMonkey/actions/runs/7934694415/job/21667006073) because the machine running too slow (maybe).
