### PR TITLE
Chore: remove the redundant python location lookup in `build.py`

### DIFF
--- a/build.py
+++ b/build.py
@@ -40,7 +40,7 @@ def run_cmake_build():
     if platform.system() == "Windows":
         execute("cmake .. -T ClangCL", cwd=BUILD_DIR) # use Clang/LLVM toolset for Visual Studio
     else:
-        execute("cmake .. -DPYTHON_INCLUDE_DIR=$(python -c 'import sysconfig; print(sysconfig.get_path('include'))') -DPYTHON_LIBRARY=$(python -c 'import sysconfig; print(sysconfig.get_config_var('LIBDIR'))')", cwd=BUILD_DIR)
+        execute("cmake ..", cwd=BUILD_DIR)
     execute(f"cmake --build . -j{CPUS} --config Release", cwd=BUILD_DIR)
 
 def copy_artifacts():


### PR DESCRIPTION
`-DPYTHON_INCLUDE_DIR=` or `-DPYTHON_LIBRARY=` are no longer needed since we have https://github.com/Distributive-Network/PythonMonkey/blob/1fcd5e4/CMakeLists.txt#L61-L63 in cmakelists. 

CMake should already be able to use the python version managed by a virtual environment with `Python_FIND_VIRTUALENV` set to `FIRST`
https://cmake.org/cmake/help/latest/module/FindPython.html 