### PR TITLE
evalOptions now work for both JSObjectProxy and Dict

### DIFF
--- a/src/modules/pythonmonkey/pythonmonkey.cc
+++ b/src/modules/pythonmonkey/pythonmonkey.cc
@@ -284,7 +284,7 @@ static bool getEvalOption(PyObject *evalOptions, const char *optionName, unsigne
   if (PyObject_TypeCheck(evalOptions, &JSObjectProxyType)) {
     value = PyMapping_GetItemString(evalOptions, optionName);
     if (value && value != Py_None) {
-      *l_p = (long)PyFloat_AsDouble(value);
+      *l_p = (unsigned long)PyFloat_AsDouble(value);
     }
   } else {
     value = PyDict_GetItemString(evalOptions, optionName);

--- a/src/modules/pythonmonkey/pythonmonkey.cc
+++ b/src/modules/pythonmonkey/pythonmonkey.cc
@@ -268,29 +268,44 @@ static PyObject *collect(PyObject *self, PyObject *args) {
 
 static bool getEvalOption(PyObject *evalOptions, const char *optionName, const char **s_p) {
   PyObject *value;
-
-  value = PyDict_GetItemString(evalOptions, optionName);
-  if (value)
+  if (PyObject_TypeCheck(evalOptions, &JSObjectProxyType)) {
+    value = PyMapping_GetItemString(evalOptions, optionName);
+  } else {
+    value = PyDict_GetItemString(evalOptions, optionName);
+  }
+  if (value && value != Py_None) {
     *s_p = PyUnicode_AsUTF8(value);
-  return value != NULL;
+  }
+  return value != NULL && value != Py_None;
 }
 
 static bool getEvalOption(PyObject *evalOptions, const char *optionName, unsigned long *l_p) {
   PyObject *value;
-
-  value = PyDict_GetItemString(evalOptions, optionName);
-  if (value)
-    *l_p = PyLong_AsUnsignedLong(value);
-  return value != NULL;
+  if (PyObject_TypeCheck(evalOptions, &JSObjectProxyType)) {
+    value = PyMapping_GetItemString(evalOptions, optionName);
+    if (value && value != Py_None) {
+      *l_p = (long)PyFloat_AsDouble(value);
+    }
+  } else {
+    value = PyDict_GetItemString(evalOptions, optionName);
+    if (value && value != Py_None) {
+      *l_p = PyLong_AsUnsignedLong(value);
+    }
+  }
+  return value != NULL && value != Py_None;
 }
 
 static bool getEvalOption(PyObject *evalOptions, const char *optionName, bool *b_p) {
   PyObject *value;
-
-  value = PyDict_GetItemString(evalOptions, optionName);
-  if (value)
+  if (PyObject_TypeCheck(evalOptions, &JSObjectProxyType)) {
+    value = PyMapping_GetItemString(evalOptions, optionName);
+  } else {
+    value = PyDict_GetItemString(evalOptions, optionName);
+  }
+  if (value && value != Py_None) {
     *b_p = PyObject_IsTrue(value) == 1 ? true : false;
-  return value != NULL;
+  }
+  return value != NULL && value != Py_None;
 }
 
 static PyObject *eval(PyObject *self, PyObject *args) {
@@ -304,7 +319,7 @@ static PyObject *eval(PyObject *self, PyObject *args) {
   }
 
   if (evalOptions && !PyDict_Check(evalOptions)) {
-    PyErr_SetString(PyExc_TypeError, "pythonmonkey.eval expects a dict as its (optional) second argument");
+    PyErr_SetString(PyExc_TypeError, "pythonmonkey.eval expects a dict as its second argument");
     return NULL;
   }
 

--- a/tests/python/test_pythonmonkey_eval.py
+++ b/tests/python/test_pythonmonkey_eval.py
@@ -290,3 +290,48 @@ def test_eval_functions_pyfunctions_strs():
 def test_globalThis():
     obj = pm.eval('globalThis')
     assert str(obj).__contains__("{'python': {'pythonMonkey':")
+
+def test_py_evaloptions_string_type():
+    evalOpts = { 'filename': 'GoodFile'}     
+    try:
+        pm.eval("{throw new Error()}", evalOpts) 
+    except Exception as e:    
+        assert str(e).__contains__("Error in file GoodFile")           
+
+def test_js_evaloptions_string_type():
+    evalOpts = pm.eval("({ 'filename': 'GoodFile'})")  
+    try:
+        pm.eval("{throw new Error()}", evalOpts) 
+    except Exception as e:    
+        assert str(e).__contains__("Error in file GoodFile")        
+
+def test_py_evaloptions_long_type():
+    evalOpts = { 'lineno': 10}     
+    try:
+        pm.eval("{throw new Error()}", evalOpts) 
+    except Exception as e:    
+        assert str(e).__contains__("on line 10")           
+
+def test_js_evaloptions_long_type():
+    evalOpts = pm.eval("({ 'lineno': 10})")  
+    try:
+        pm.eval("{throw new Error()}", evalOpts) 
+    except Exception as e:    
+        assert str(e).__contains__("on line 10")     
+
+def test_py_evaloptions_boolean_type():
+    evalOpts = { 'strict': True}     
+    try:
+        pm.eval("{a = 9}", evalOpts) 
+    except Exception as e:    
+        assert str(e).__contains__("ReferenceError: assignment to undeclared variable a")           
+
+def test_js_evaloptions_boolean_type():
+    evalOpts = pm.eval("({ 'strict': true})")  
+    try:
+        pm.eval("{a = 9}", evalOpts) 
+    except Exception as e:    
+        assert str(e).__contains__("ReferenceError: assignment to undeclared variable a")  
+
+
+

--- a/tests/python/test_pythonmonkey_eval.py
+++ b/tests/python/test_pythonmonkey_eval.py
@@ -331,7 +331,4 @@ def test_js_evaloptions_boolean_type():
     try:
         pm.eval("{a = 9}", evalOpts) 
     except Exception as e:    
-        assert str(e).__contains__("ReferenceError: assignment to undeclared variable a")  
-
-
-
+        assert str(e).__contains__("ReferenceError: assignment to undeclared variable a")

--- a/tests/python/test_pythonmonkey_eval.py
+++ b/tests/python/test_pythonmonkey_eval.py
@@ -292,42 +292,42 @@ def test_globalThis():
     assert str(obj).__contains__("{'python': {'pythonMonkey':")
 
 def test_py_evaloptions_string_type():
-    evalOpts = { 'filename': 'GoodFile'}     
+    evalOpts = {'filename': 'GoodFile'}     
     try:
         pm.eval("{throw new Error()}", evalOpts) 
     except Exception as e:    
         assert str(e).__contains__("Error in file GoodFile")           
 
 def test_js_evaloptions_string_type():
-    evalOpts = pm.eval("({ 'filename': 'GoodFile'})")  
+    evalOpts = pm.eval("({'filename': 'GoodFile'})")  
     try:
         pm.eval("{throw new Error()}", evalOpts) 
     except Exception as e:    
         assert str(e).__contains__("Error in file GoodFile")        
 
 def test_py_evaloptions_long_type():
-    evalOpts = { 'lineno': 10}     
+    evalOpts = {'lineno': 10}     
     try:
         pm.eval("{throw new Error()}", evalOpts) 
     except Exception as e:    
         assert str(e).__contains__("on line 10")           
 
 def test_js_evaloptions_long_type():
-    evalOpts = pm.eval("({ 'lineno': 10})")  
+    evalOpts = pm.eval("({'lineno': 10})")  
     try:
         pm.eval("{throw new Error()}", evalOpts) 
     except Exception as e:    
         assert str(e).__contains__("on line 10")     
 
 def test_py_evaloptions_boolean_type():
-    evalOpts = { 'strict': True}     
+    evalOpts = {'strict': True}     
     try:
         pm.eval("{a = 9}", evalOpts) 
     except Exception as e:    
         assert str(e).__contains__("ReferenceError: assignment to undeclared variable a")           
 
 def test_js_evaloptions_boolean_type():
-    evalOpts = pm.eval("({ 'strict': true})")  
+    evalOpts = pm.eval("({'strict': true})")  
     try:
         pm.eval("{a = 9}", evalOpts) 
     except Exception as e:    


### PR DESCRIPTION
Parsing of options given to pm.eval now works for both JS and Python options types 

closes https://github.com/Distributive-Network/PythonMonkey/issues/258
closes https://github.com/Distributive-Network/PythonMonkey/issues/259