### PR TITLE
pmjs - fix .python command, peter-jr - fix sigint

### DIFF
--- a/peter-jr
+++ b/peter-jr
@@ -142,6 +142,7 @@ findTests \
 | (shuf 2>/dev/null || cat) \
 | while read file
   do
+    trap 'echo -e "\nAborted." >&2; exit 130' 2
     printf "Testing %-${longestFilenameLen}s ... " "${file}"
     ext="${file##*.}"
     testName="${file%.failing}"
@@ -168,7 +169,7 @@ findTests \
           exitCode="$?"
           ;;
         "bash")
-          eval timeout -s9 "${timeout:-${defaultTimeout}}" bash \"$file\"
+          eval timeout -s9 --foreground "${timeout:-${defaultTimeout}}" bash \"$file\"
           exitCode="$?"
           ;;
         *)

--- a/python/pythonmonkey/cli/pmjs.py
+++ b/python/pythonmonkey/cli/pmjs.py
@@ -35,6 +35,7 @@ Press Ctrl+C to abort current expression, Ctrl+D to exit the REPL`
 
 cmds.exit = python.exit;
 cmds.python = function pythonCmd(...args) {
+  var retval;
   const cmd = args.join(' ').trim();
 
   if (cmd === 'reset')
@@ -46,23 +47,20 @@ cmds.python = function pythonCmd(...args) {
   }
 
   if (cmd === '')
-  {
     return;
-  }
-  
-  try {
-    if (arguments[0] === 'from' || arguments[0] === 'import')
-    {
-      return python.exec(cmd);
-    }
 
-    const retval = python.eval(cmd);
+  try
+  {
+    if (arguments[0] === 'from' || arguments[0] === 'import')
+      return python.exec(cmd);
+    retval = python.eval(cmd);
   }
-  catch(error) {
+  catch(error)
+  {
     globalThis._error = error;
     return util.inspect(error);
   }
-  
+
   pythonCmd.serial = (pythonCmd.serial || 0) + 1;
   globalThis['$' + pythonCmd.serial] = retval;
   python.stdout.write('$' + pythonCmd.serial + ' = ');
@@ -72,7 +70,7 @@ cmds.python = function pythonCmd(...args) {
 /**
  * Handle a .xyz repl command. Invokes function cmds[XXX], passing arguments that the user typed as the
  * function arguments. The function arguments are space-delimited arguments; arguments surrounded by
- * quotes can include spaces, similar to how bash parses arguments. Argument parsing cribbed from 
+ * quotes can include spaces, similar to how bash parses arguments. Argument parsing cribbed from
  * stackoverflow user Tsuneo Yoshioka, question 4031900.
  *
  * @param {string} cmdLine     the command the user typed, without the leading .
@@ -107,9 +105,9 @@ globalThis.replEval = function replEval(statement)
   var result;
   var mightBeObjectLiteral = false;
 
-  /* A statement which starts with a { and does not end with a ; is treated as an object literal, 
+  /* A statement which starts with a { and does not end with a ; is treated as an object literal,
    * and to get the parser in to Expression mode instead of Statement mode, we surround any expression
-   * like that which is also a valid compilation unit with parens, then if that is a syntax error, 
+   * like that which is also a valid compilation unit with parens, then if that is a syntax error,
    * we re-evaluate without the parens.
    */
   if (/^\\s*\\{.*[^;\\s]\\s*$/.test(statement))
@@ -152,7 +150,7 @@ def repl():
     Start a REPL to evaluate JavaScript code in the extra-module environment. Multi-line statements and
     readline history are supported. ^C support is sketchy. Exit the REPL with ^D or ".quit".
     """
-    
+
     print('Welcome to PythonMonkey v' + pm.__version__ +'.')
     print('Type ".help" for more information.')
     readline.parse_and_bind('set editing-mode emacs')
@@ -167,7 +165,7 @@ def repl():
     statement = ''
     readline_skip_chars = 0
     inner_loop = False
-    
+
     def save_history():
         nonlocal histfile
         readline.write_history_file(histfile)
@@ -240,7 +238,7 @@ def repl():
             if (statement == ""):
                 statement = input('> ')[readline_skip_chars:]
             readline_skip_chars = 0
-            
+
             if (len(statement) == 0):
                 continue
             if (statement[0] == '.'):
@@ -291,7 +289,7 @@ Options:
   -v, --version        print PythonMonkey version
   --use-strict         evaluate -e, -p, and REPL code in strict mode
   --inspect            enable pmdb, a gdb-like JavaScript debugger interface
-  
+
 Environment variables:
 TZ                            specify the timezone configuration
 PMJS_PATH                     ':'-separated list of directories prefixed to the module search path
@@ -322,7 +320,7 @@ def main():
     forceRepl = False
     globalInitModule = initGlobalThis()
     global requirePath
-    
+
     try:
         opts, args = getopt.getopt(sys.argv[1:], "hie:p:r:v", ["help", "eval=", "print=", "require=", "version", "interactive", "use-strict", "inspect"])
     except getopt.GetoptError as err:


### PR DESCRIPTION
There have been some pmjs regressions over the last year
 - .python command is broken
 -  sigint no longer aborts peter-jr
 
 Update: sigint problem was actually peter-jr, not pmjs
 
 both problems fixed in this PR