### PR TITLE
pm.eval - support open file as first arg, issue 230

### DIFF
--- a/src/modules/pythonmonkey/pythonmonkey.cc
+++ b/src/modules/pythonmonkey/pythonmonkey.cc
@@ -308,21 +308,55 @@ static bool getEvalOption(PyObject *evalOptions, const char *optionName, bool *b
   return value != NULL && value != Py_None;
 }
 
+/**
+ * Implement the pythonmonkey.eval function. From Python-land, that function has the following API:
+ * argument 0 - unicode string of JS code or open file containing JS code in UTF-8
+ * argument 1 - a Dict of options which roughly correspond to the jsapi CompileOptions. A novel option,
+ *              fromPythonFrame, sets the filename and line offset according to the pm.eval call in the
+ *              Python source code. This allows us to embed non-trivial JS inside Python source files
+ *              and still get stack dumps which point to the source code.
+ */
 static PyObject *eval(PyObject *self, PyObject *args) {
   size_t argc = PyTuple_GET_SIZE(args);
-  StrType *code = new StrType(PyTuple_GetItem(args, 0));
-  PyObject *evalOptions = argc == 2 ? PyTuple_GetItem(args, 1) : NULL;
-
-  if (argc == 0 || !PyUnicode_Check(code->getPyObject())) {
-    PyErr_SetString(PyExc_TypeError, "pythonmonkey.eval expects a string as its first argument");
+  if (argc > 2 || argc == 0) {
+    PyErr_SetString(PyExc_TypeError, "pythonmonkey.eval one or two arguments");
     return NULL;
   }
 
+  StrType *code = NULL;
+  FILE *file;
+  PyObject *arg0 = PyTuple_GetItem(args, 0);
+  PyObject *arg1 = argc == 2 ? PyTuple_GetItem(args, 1) : NULL;
+
+  if (PyUnicode_Check(arg0)) {
+    code = new StrType(arg0);
+    if (!code || !PyUnicode_Check(code->getPyObject())) {
+      PyErr_SetString(PyExc_TypeError, "JS code must originate from a Unicode string");
+      return NULL;
+    }
+  } else if (1 /*PyFile_Check(arg0)*/) {
+    /* First argument is an open file. Open a stream with a dup of the underlying fd (so we can fclose
+     * the stream later).
+     */
+    int fd = PyObject_AsFileDescriptor(arg0);
+    int fd2 = fd == -1 ? -1 : dup(fd);
+    file = fd2 == -1 ? NULL : fdopen(fd, "rb");
+    if (!file) {
+      PyErr_SetString(PyExc_TypeError, "error opening file stream");
+      return NULL;
+    }
+  } else {
+    PyErr_SetString(PyExc_TypeError, "pythonmonkey.eval expects either a string or an open file as its first argument");
+    return NULL;
+  }
+
+  PyObject *evalOptions = argc == 2 ? arg1 : NULL;
   if (evalOptions && !PyDict_Check(evalOptions)) {
     PyErr_SetString(PyExc_TypeError, "pythonmonkey.eval expects a dict as its second argument");
     return NULL;
   }
 
+  // initialize JS context
   JSAutoRealm ar(GLOBAL_CX, *global);
   JS::CompileOptions options (GLOBAL_CX);
   options.setFileAndLine("evaluate", 1)
@@ -365,17 +399,30 @@ static PyObject *eval(PyObject *self, PyObject *args) {
       } /* filename */
     } /* fromPythonFrame */
   } /* eval options */
-    // initialize JS context
-  JS::SourceText<mozilla::Utf8Unit> source;
-  if (!source.init(GLOBAL_CX, code->getValue(), strlen(code->getValue()), JS::SourceOwnership::Borrowed)) {
+
+  // compile the code to execute
+  JS::RootedScript script(GLOBAL_CX);
+  JS::Rooted<JS::Value> *rval = new JS::Rooted<JS::Value>(GLOBAL_CX);
+  if (code) {
+    JS::SourceText<mozilla::Utf8Unit> source;
+    if (!source.init(GLOBAL_CX, code->getValue(), strlen(code->getValue()), JS::SourceOwnership::Borrowed)) {
+      setSpiderMonkeyException(GLOBAL_CX);
+      return NULL;
+    }
+    delete code;
+    script = JS::Compile(GLOBAL_CX, options, source);
+  } else {
+    script = JS::CompileUtf8File(GLOBAL_CX, options, file);
+    fclose(file);
+  }
+
+  if (!script) {
     setSpiderMonkeyException(GLOBAL_CX);
     return NULL;
   }
-  delete code;
 
-  // evaluate source code
-  JS::Rooted<JS::Value> *rval = new JS::Rooted<JS::Value>(GLOBAL_CX);
-  if (!JS::Evaluate(GLOBAL_CX, options, source, rval)) {
+  // execute the compiled code; last expr goes to rval
+  if (!JS_ExecuteScript(GLOBAL_CX, script, rval)) {
     setSpiderMonkeyException(GLOBAL_CX);
     return NULL;
   }

--- a/src/modules/pythonmonkey/pythonmonkey.cc
+++ b/src/modules/pythonmonkey/pythonmonkey.cc
@@ -319,7 +319,7 @@ static bool getEvalOption(PyObject *evalOptions, const char *optionName, bool *b
 static PyObject *eval(PyObject *self, PyObject *args) {
   size_t argc = PyTuple_GET_SIZE(args);
   if (argc > 2 || argc == 0) {
-    PyErr_SetString(PyExc_TypeError, "pythonmonkey.eval one or two arguments");
+    PyErr_SetString(PyExc_TypeError, "pythonmonkey.eval accepts one or two arguments");
     return NULL;
   }
 

--- a/tests/js/eval-test.simple
+++ b/tests/js/eval-test.simple
@@ -1,0 +1,12 @@
+/**
+ * @file         eval-test.simple
+ *               A test that makes sure we can correctly evaluate a JS file
+ * @copyright    Copyright (c) 2024, Distributve Corp
+ * @author       Wes Garland, wes@distributive.network
+ * @date         March 2024
+ */ 
+'use strict';
+
+const result = python.eval(`pm.eval(open("${__dirname}/resources/eval-test.js", "rb"))`);
+if (result !== 18436572)
+  throw new Error('incorrect result from eval-test.js');

--- a/tests/js/resources/eval-test.js
+++ b/tests/js/resources/eval-test.js
@@ -1,0 +1,2 @@
+console.log('eval-test.js loaded from', __filename);
+18436572;


### PR DESCRIPTION
Now we can pass a python file as the first arg to pm.eval.  The JSAPI code assumes the file is in UTF-8 and does not blow it up to char16_t before compilation.

This means that we don't need to load the giant dcp-client bundle into memory and convert from utf8 to ucs2 before execution just to throw it all away a few lines later.