### PR TITLE
pmjs timeout improvements

### DIFF
--- a/python/pythonmonkey/cli/pmjs.py
+++ b/python/pythonmonkey/cli/pmjs.py
@@ -147,7 +147,7 @@ globalThis.replEval = function replEval(statement)
 }
 """, evalOpts);
 
-def repl():
+async def repl():
     """
     Start a REPL to evaluate JavaScript code in the extra-module environment. Multi-line statements and
     readline history are supported. ^C support is sketchy. Exit the REPL with ^D or ".quit".
@@ -179,7 +179,7 @@ def repl():
         """
         Quit the REPL. Repl saved by atexit handler.
         """
-        sys.exit(0)
+        globalThis.python.exit(); # need for python.exit.code in require.py
 
     def sigint_handler(signum, frame):
         """
@@ -236,6 +236,7 @@ def repl():
     #
     while got_sigint < 2:
         try:
+            await asyncio.sleep(0)
             inner_loop = False
             if (statement == ""):
                 statement = input('> ')[readline_skip_chars:]
@@ -260,6 +261,7 @@ def repl():
                 # SIGINT is received, so we have to patch things up so that the next-entered line is
                 # treated as the input at the top of the loop.
                 while (got_sigint == 0):
+                    await asyncio.sleep(0)
                     inner_loop = True
                     lineBuffer = input('... ')
                     more = lineBuffer[readline_skip_chars:]
@@ -363,8 +365,13 @@ def main():
             await pm.wait() # blocks until all asynchronous calls finish
         asyncio.run(runJS())
     elif (enterRepl or forceRepl):
-        globalInitModule.initReplLibs()
-        repl()
+        async def runREPL():
+            globalInitModule.initReplLibs()
+            await repl()
+            await pm.wait()
+        asyncio.run(runREPL())
+
+    globalThis.python.exit(); # need for python.exit.code in require.py
 
 if __name__ == "__main__":
     main()

--- a/python/pythonmonkey/require.py
+++ b/python/pythonmonkey/require.py
@@ -70,8 +70,14 @@ globalThis.python.paths  = sys.path
 
 globalThis.python.exit = pm.eval("""'use strict';
 (exit) => function pythonExitWrapper(exitCode) {
+  if (typeof exitCode === 'undefined')
+    exitCode = pythonExitWrapper.code;
+  if (typeof exitCode == 'undefined')
+    exitCode = 0n;
   if (typeof exitCode === 'number')
     exitCode = BigInt(Math.floor(exitCode));
+  if (typeof exitCode !== 'bigint')
+    exitCode = 1n;
   exit(exitCode);
 }
 """, evalOpts)(sys.exit);

--- a/tests/js/set-timeout.simple
+++ b/tests/js/set-timeout.simple
@@ -1,0 +1,32 @@
+/**
+ * @file        set-timeout.simple
+ *              Simple test which ensures that setTimeout() fires, and that it fires at about the right
+ *              time.
+ * @author      Wes Garland, wes@distributive.network
+ * @date        June 2023
+ */
+
+const time = python.eval('__import__("time").time');
+const start = time();
+
+/**
+ * - must fire later than 100ms
+ * - must fire before 10s
+ * - 10s is will before 100s but very CI-load-tolerant; the idea is not to check for accurancy, but
+ *  rather ensure we haven't mixed up seconds and milliseconds somewhere.
+ */
+function check100ms()
+{
+  end = time();
+
+  if (end - start < 0.1)
+    throw new Error('timer fired too soon');
+  if (end - start > 10)
+    throw new Error('timer fired too late');
+
+  console.log('done - timer fired after ', (end-start) * 1000, 'ms');
+  python.exit.code = 0;
+}
+
+python.exit.code = 2;
+setTimeout(check100ms, 100);

--- a/tests/js/set-timeout.simple
+++ b/tests/js/set-timeout.simple
@@ -3,7 +3,7 @@
  *              Simple test which ensures that setTimeout() fires, and that it fires at about the right
  *              time.
  * @author      Wes Garland, wes@distributive.network
- * @date        June 2023
+ * @date        March 2024
  */
 
 const time = python.eval('__import__("time").time');
@@ -12,7 +12,7 @@ const start = time();
 /**
  * - must fire later than 100ms
  * - must fire before 10s
- * - 10s is will before 100s but very CI-load-tolerant; the idea is not to check for accurancy, but
+ * - 10s is well before 100s but very CI-load-tolerant; the idea is not to check for accurancy, but
  *  rather ensure we haven't mixed up seconds and milliseconds somewhere.
  */
 function check100ms()


### PR DESCRIPTION
- can now use timers inside pmjs REPL, although they can only fire after you press enter
- there is now a set timeout test
- this test required my to add process.exit.code feature to require.py so that we didn't have false positives when the timer just never fired