### PR TITLE
Feat: Node.js-style timers

### DIFF
--- a/include/PyEventLoop.hh
+++ b/include/PyEventLoop.hh
@@ -128,14 +128,14 @@ public:
    * @param jobFn - The JS event-loop job converted to a Python function
    * @return a AsyncHandle, the value can be safely ignored
    */
-  AsyncHandle::id_ptr_pair enqueue(PyObject *jobFn);
+  AsyncHandle enqueue(PyObject *jobFn);
   /**
    * @brief Schedule a job to the Python event-loop, with the given delay
    * @param jobFn - The JS event-loop job converted to a Python function
    * @param delaySeconds - The job function will be called after the given number of seconds
-   * @return a AsyncHandle, the value can be safely ignored
+   * @return the timeoutId and a pointer to the AsyncHandle
    */
-  AsyncHandle::id_ptr_pair enqueueWithDelay(PyObject *jobFn, double delaySeconds);
+  [[nodiscard]] AsyncHandle::id_ptr_pair enqueueWithDelay(PyObject *jobFn, double delaySeconds);
 
   /**
    * @brief C++ wrapper for Python `asyncio.Future` class

--- a/include/PyEventLoop.hh
+++ b/include/PyEventLoop.hh
@@ -72,8 +72,30 @@ public:
       Py_INCREF(_handle); // otherwise the object would be GC-ed as the AsyncHandle destructor decreases the reference count
       return _handle;
     }
+
+    /**
+     * @brief Getter for if the timer has been ref'ed
+     */
+    inline bool hasRef() {
+      return _refed;
+    }
+
+    /**
+     * @brief Ref the timer so that the event-loop won't exit as long as the timer is active
+     */
+    inline void addRef() {
+      _refed = true;
+    }
+
+    /**
+     * @brief Unref the timer so that the event-loop can exit
+     */
+    inline void removeRef() {
+      _refed = false;
+    }
   protected:
     PyObject *_handle;
+    bool _refed;
   };
 
   /**

--- a/python/pythonmonkey/builtin_modules/internal-binding.d.ts
+++ b/python/pythonmonkey/builtin_modules/internal-binding.d.ts
@@ -43,6 +43,21 @@ declare function internalBinding(namespace: "timers"): {
    * internal binding helper for the `clearTimeout` global function
    */
   cancelByTimeoutId(timeoutId: number): void;
+
+  /**
+   * internal binding helper for if a timer object has been ref'ed
+   */
+  timerHasRef(timeoutId: number): boolean;
+
+  /**
+   * internal binding helper for ref'ing the timer
+   */
+  timerAddRef(timeoutId: number): void;
+
+  /**
+   * internal binding helper for unref'ing the timer
+   */
+  timerRemoveRef(timeoutId: number): void;
 };
 
 export = internalBinding;

--- a/python/pythonmonkey/builtin_modules/timers.js
+++ b/python/pythonmonkey/builtin_modules/timers.js
@@ -16,7 +16,10 @@ const {
  */
 class Timeout
 {
+  /** @type {number} an integer */
   #numeralId;
+  /** @type {boolean} */
+  #refed;
 
   /**
    * @param {number} numeralId 
@@ -24,6 +27,36 @@ class Timeout
   constructor(numeralId)
   {
     this.#numeralId = numeralId;
+  }
+
+  /**
+   * If `true`, the `Timeout` object will keep the event-loop active.
+   * @returns {boolean}
+   */
+  hasRef()
+  {
+    return this.#refed;
+  }
+
+  /**
+   * When called, requests that the event-loop **not exit** so long as the `Timeout` is active.
+   *   
+   * By default, all `Timeout` objects are "ref'ed", making it normally unnecessary to call `timeout.ref()` unless `timeout.unref()` had been called previously.
+   */
+  ref()
+  {
+    this.#refed = true;
+    return this; // allow chaining
+  }
+
+  /**
+   * When called, the active `Timeout` object will not require the event-loop to remain active.  
+   * If there is no other activity keeping the event-loop running, the process may exit before the `Timeout` object's callback is invoked.
+   */
+  unref()
+  {
+    this.#refed = false;
+    return this; // allow chaining
   }
 
   /**

--- a/python/pythonmonkey/builtin_modules/timers.js
+++ b/python/pythonmonkey/builtin_modules/timers.js
@@ -102,9 +102,6 @@ function setTimeout(handler, delayMs = 0, ...args)
   return new Timeout(enqueueWithDelay(boundHandler, delaySeconds));
 }
 
-// expose the `Timeout` class
-setTimeout.Timeout = Timeout;
-
 /**
  * Implement the `clearTimeout` global function
  * @see https://developer.mozilla.org/en-US/docs/Web/API/clearTimeout and
@@ -120,6 +117,9 @@ function clearTimeout(timeoutId)
 
   return cancelByTimeoutId(Number(timeoutId));
 }
+
+// expose the `Timeout` class
+setTimeout.Timeout = Timeout;
 
 if (!globalThis.setTimeout)
   globalThis.setTimeout = setTimeout;

--- a/python/pythonmonkey/builtin_modules/timers.js
+++ b/python/pythonmonkey/builtin_modules/timers.js
@@ -7,7 +7,10 @@ const internalBinding = require('internal-binding');
 
 const { 
   enqueueWithDelay,
-  cancelByTimeoutId
+  cancelByTimeoutId,
+  timerHasRef,
+  timerAddRef,
+  timerRemoveRef,
 } = internalBinding('timers');
 
 /**
@@ -17,16 +20,14 @@ const {
 class Timeout
 {
   /** @type {number} an integer */
-  #numeralId;
-  /** @type {boolean} */
-  #refed;
+  #numericId;
 
   /**
-   * @param {number} numeralId 
+   * @param {number} numericId 
    */
-  constructor(numeralId)
+  constructor(numericId)
   {
-    this.#numeralId = numeralId;
+    this.#numericId = numericId;
   }
 
   /**
@@ -35,7 +36,7 @@ class Timeout
    */
   hasRef()
   {
-    return this.#refed;
+    return timerHasRef(this.#numericId);
   }
 
   /**
@@ -45,7 +46,7 @@ class Timeout
    */
   ref()
   {
-    this.#refed = true;
+    timerAddRef(this.#numericId);
     return this; // allow chaining
   }
 
@@ -55,7 +56,7 @@ class Timeout
    */
   unref()
   {
-    this.#refed = false;
+    timerRemoveRef(this.#numericId);
     return this; // allow chaining
   }
 
@@ -64,7 +65,7 @@ class Timeout
    */
   [Symbol.toPrimitive]()
   {
-    return this.#numeralId;
+    return this.#numericId;
   }
 }
 

--- a/python/pythonmonkey/builtin_modules/timers.js
+++ b/python/pythonmonkey/builtin_modules/timers.js
@@ -67,6 +67,15 @@ class Timeout
   {
     return this.#numericId;
   }
+
+  /**
+   * Cancels the timeout.
+   * @deprecated legacy Node.js API. Use `clearTimeout()` instead
+   */
+  close()
+  {
+    return clearTimeout(this);
+  }
 }
 
 /**

--- a/src/PyEventLoop.cc
+++ b/src/PyEventLoop.cc
@@ -3,13 +3,13 @@
 #include <Python.h>
 
 /**
- * @brief Wrapper to decrement the counter of queueing event-loop jobs after the job finishes
+ * @brief Wrapper to remove the reference of the queueing event-loop job after the job finishes
  */
 static PyObject *eventLoopJobWrapper(PyObject *jobFn, PyObject *handlerPtr) {
   auto handle = (PyEventLoop::AsyncHandle *)PyLong_AsVoidPtr(handlerPtr);
+  handle->removeRef();
   PyObject *ret = PyObject_CallObject(jobFn, NULL); // jobFn()
   Py_XDECREF(ret); // don't care about its return value
-  handle->removeRef();
   if (PyErr_Occurred()) {
     return NULL;
   } else {

--- a/src/PyEventLoop.cc
+++ b/src/PyEventLoop.cc
@@ -8,7 +8,6 @@
 static PyObject *eventLoopJobWrapper(PyObject *jobFn, PyObject *Py_UNUSED(_)) {
   PyObject *ret = PyObject_CallObject(jobFn, NULL); // jobFn()
   Py_XDECREF(ret); // don't care about its return value
-  Py_XDECREF(jobFn);
   PyEventLoop::_locker->decCounter();
   if (PyErr_Occurred()) {
     return NULL;
@@ -25,7 +24,6 @@ static PyObject *timerJobWrapper(PyObject *jobFn, PyObject *handlerPtr) {
   auto handle = (PyEventLoop::AsyncHandle *)PyLong_AsVoidPtr(handlerPtr);
   PyObject *ret = PyObject_CallObject(jobFn, NULL); // jobFn()
   Py_XDECREF(ret); // don't care about its return value
-  Py_XDECREF(jobFn);
   handle->removeRef();
   if (PyErr_Occurred()) {
     return NULL;
@@ -40,7 +38,7 @@ PyEventLoop::AsyncHandle PyEventLoop::enqueue(PyObject *jobFn) {
   PyObject *wrapper = PyCFunction_New(&loopJobWrapperDef, jobFn);
   // Enqueue job to the Python event-loop
   //    https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.loop.call_soon
-  PyObject *asyncHandle = PyObject_CallMethod(_loop, "call_soon_threadsafe", "N", wrapper); // https://docs.python.org/3/c-api/arg.html#c.Py_BuildValue
+  PyObject *asyncHandle = PyObject_CallMethod(_loop, "call_soon_threadsafe", "O", wrapper); // https://docs.python.org/3/c-api/arg.html#c.Py_BuildValue
   return PyEventLoop::AsyncHandle(asyncHandle);
 }
 
@@ -50,7 +48,7 @@ PyEventLoop::AsyncHandle::id_ptr_pair PyEventLoop::enqueueWithDelay(PyObject *jo
   PyObject *handlerPtr = PyLong_FromVoidPtr(handler.second);
   // Schedule job to the Python event-loop
   //    https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.loop.call_later
-  PyObject *asyncHandle = PyObject_CallMethod(_loop, "call_later", "dNN", delaySeconds, wrapper, handlerPtr); // https://docs.python.org/3/c-api/arg.html#c.Py_BuildValue
+  PyObject *asyncHandle = PyObject_CallMethod(_loop, "call_later", "dOO", delaySeconds, wrapper, handlerPtr); // https://docs.python.org/3/c-api/arg.html#c.Py_BuildValue
   if (asyncHandle == nullptr) {
     PyErr_Print(); // RuntimeError: Non-thread-safe operation invoked on an event loop other than the current one
     return handler;

--- a/src/PyEventLoop.cc
+++ b/src/PyEventLoop.cc
@@ -8,6 +8,7 @@
 static PyObject *eventLoopJobWrapper(PyObject *jobFn, PyObject *Py_UNUSED(_)) {
   PyObject *ret = PyObject_CallObject(jobFn, NULL); // jobFn()
   Py_XDECREF(ret); // don't care about its return value
+  Py_XDECREF(jobFn);
   PyEventLoop::_locker->decCounter();
   if (PyErr_Occurred()) {
     return NULL;
@@ -22,8 +23,10 @@ static PyMethodDef loopJobWrapperDef = {"eventLoopJobWrapper", eventLoopJobWrapp
  */
 static PyObject *timerJobWrapper(PyObject *jobFn, PyObject *handlerPtr) {
   auto handle = (PyEventLoop::AsyncHandle *)PyLong_AsVoidPtr(handlerPtr);
+  Py_XDECREF(handlerPtr);
   PyObject *ret = PyObject_CallObject(jobFn, NULL); // jobFn()
   Py_XDECREF(ret); // don't care about its return value
+  Py_XDECREF(jobFn);
   handle->removeRef();
   if (PyErr_Occurred()) {
     return NULL;
@@ -38,7 +41,7 @@ PyEventLoop::AsyncHandle PyEventLoop::enqueue(PyObject *jobFn) {
   PyObject *wrapper = PyCFunction_New(&loopJobWrapperDef, jobFn);
   // Enqueue job to the Python event-loop
   //    https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.loop.call_soon
-  PyObject *asyncHandle = PyObject_CallMethod(_loop, "call_soon_threadsafe", "O", wrapper); // https://docs.python.org/3/c-api/arg.html#c.Py_BuildValue
+  PyObject *asyncHandle = PyObject_CallMethod(_loop, "call_soon_threadsafe", "N", wrapper); // https://docs.python.org/3/c-api/arg.html#c.Py_BuildValue
   return PyEventLoop::AsyncHandle(asyncHandle);
 }
 
@@ -48,7 +51,7 @@ PyEventLoop::AsyncHandle::id_ptr_pair PyEventLoop::enqueueWithDelay(PyObject *jo
   PyObject *handlerPtr = PyLong_FromVoidPtr(handler.second);
   // Schedule job to the Python event-loop
   //    https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.loop.call_later
-  PyObject *asyncHandle = PyObject_CallMethod(_loop, "call_later", "dOO", delaySeconds, wrapper, handlerPtr); // https://docs.python.org/3/c-api/arg.html#c.Py_BuildValue
+  PyObject *asyncHandle = PyObject_CallMethod(_loop, "call_later", "dNN", delaySeconds, wrapper, handlerPtr); // https://docs.python.org/3/c-api/arg.html#c.Py_BuildValue
   if (asyncHandle == nullptr) {
     PyErr_Print(); // RuntimeError: Non-thread-safe operation invoked on an event loop other than the current one
     return handler;

--- a/src/PyEventLoop.cc
+++ b/src/PyEventLoop.cc
@@ -6,9 +6,9 @@
  * @brief Wrapper to decrement the counter of queueing event-loop jobs after the job finishes
  */
 static PyObject *eventLoopJobWrapper(PyObject *jobFn, PyObject *handlerPtr) {
+  auto handle = (PyEventLoop::AsyncHandle *)PyLong_AsVoidPtr(handlerPtr);
   PyObject *ret = PyObject_CallObject(jobFn, NULL); // jobFn()
   Py_XDECREF(ret); // don't care about its return value
-  auto handle = (PyEventLoop::AsyncHandle *)PyLong_AsVoidPtr(handlerPtr);
   handle->removeRef();
   if (PyErr_Occurred()) {
     return NULL;

--- a/src/PyEventLoop.cc
+++ b/src/PyEventLoop.cc
@@ -23,7 +23,6 @@ static PyMethodDef loopJobWrapperDef = {"eventLoopJobWrapper", eventLoopJobWrapp
  */
 static PyObject *timerJobWrapper(PyObject *jobFn, PyObject *handlerPtr) {
   auto handle = (PyEventLoop::AsyncHandle *)PyLong_AsVoidPtr(handlerPtr);
-  Py_XDECREF(handlerPtr);
   PyObject *ret = PyObject_CallObject(jobFn, NULL); // jobFn()
   Py_XDECREF(ret); // don't care about its return value
   Py_XDECREF(jobFn);

--- a/src/PyEventLoop.cc
+++ b/src/PyEventLoop.cc
@@ -5,40 +5,44 @@
 /**
  * @brief Wrapper to decrement the counter of queueing event-loop jobs after the job finishes
  */
-static PyObject *eventLoopJobWrapper(PyObject *jobFn, PyObject *Py_UNUSED(_)) {
+static PyObject *eventLoopJobWrapper(PyObject *jobFn, PyObject *handlerPtr) {
   PyObject *ret = PyObject_CallObject(jobFn, NULL); // jobFn()
   Py_XDECREF(ret); // don't care about its return value
-  PyEventLoop::_locker->decCounter();
+  auto handle = (PyEventLoop::AsyncHandle *)PyLong_AsVoidPtr(handlerPtr);
+  handle->removeRef();
   if (PyErr_Occurred()) {
     return NULL;
   } else {
     Py_RETURN_NONE;
   }
 }
-static PyMethodDef jobWrapperDef = {"eventLoopJobWrapper", eventLoopJobWrapper, METH_NOARGS, NULL};
+static PyMethodDef jobWrapperDef = {"eventLoopJobWrapper", eventLoopJobWrapper, METH_O, NULL};
 
 PyEventLoop::AsyncHandle::id_ptr_pair PyEventLoop::enqueue(PyObject *jobFn) {
   auto handler = PyEventLoop::AsyncHandle::newEmpty();
-  PyEventLoop::_locker->incCounter();
   PyObject *wrapper = PyCFunction_New(&jobWrapperDef, jobFn);
+  PyObject *handlerPtr = PyLong_FromVoidPtr(handler.second);
   // Enqueue job to the Python event-loop
   //    https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.loop.call_soon
-  PyObject *asyncHandle = PyObject_CallMethod(_loop, "call_soon_threadsafe", "O", wrapper); // https://docs.python.org/3/c-api/arg.html#c.Py_BuildValue
+  PyObject *asyncHandle = PyObject_CallMethod(_loop, "call_soon_threadsafe", "OO", wrapper, handlerPtr); // https://docs.python.org/3/c-api/arg.html#c.Py_BuildValue
   handler.second->swap(asyncHandle);
+  handler.second->addRef();
   return handler;
 }
 
 PyEventLoop::AsyncHandle::id_ptr_pair PyEventLoop::enqueueWithDelay(PyObject *jobFn, double delaySeconds) {
   auto handler = PyEventLoop::AsyncHandle::newEmpty();
-  PyEventLoop::_locker->incCounter();
   PyObject *wrapper = PyCFunction_New(&jobWrapperDef, jobFn);
+  PyObject *handlerPtr = PyLong_FromVoidPtr(handler.second);
   // Schedule job to the Python event-loop
   //    https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.loop.call_later
-  PyObject *asyncHandle = PyObject_CallMethod(_loop, "call_later", "dO", delaySeconds, wrapper); // https://docs.python.org/3/c-api/arg.html#c.Py_BuildValue
+  PyObject *asyncHandle = PyObject_CallMethod(_loop, "call_later", "dOO", delaySeconds, wrapper, handlerPtr); // https://docs.python.org/3/c-api/arg.html#c.Py_BuildValue
   if (asyncHandle == nullptr) {
     PyErr_Print(); // RuntimeError: Non-thread-safe operation invoked on an event loop other than the current one
+    return handler;
   }
   handler.second->swap(asyncHandle);
+  handler.second->addRef();
   return handler;
 }
 
@@ -149,7 +153,7 @@ void PyEventLoop::AsyncHandle::cancel() {
                                                                        // NULL if no such attribute (on a strict asyncio.Handle returned by loop.call_soon)
   bool finishedOrCanceled = scheduled && scheduled == Py_False; // the job function has already been executed or canceled
   if (!finishedOrCanceled) {
-    PyEventLoop::_locker->decCounter();
+    removeRef(); // automatically unref at finish
   }
   Py_XDECREF(scheduled);
 

--- a/src/internalBinding/timers.cc
+++ b/src/internalBinding/timers.cc
@@ -31,10 +31,10 @@ static bool enqueueWithDelay(JSContext *cx, unsigned argc, JS::Value *vp) {
   // Schedule job to the running Python event-loop
   PyEventLoop loop = PyEventLoop::getRunningLoop();
   if (!loop.initialized()) return false;
-  PyEventLoop::AsyncHandle handle = loop.enqueueWithDelay(job, delaySeconds);
+  PyEventLoop::AsyncHandle::id_ptr_pair handler = loop.enqueueWithDelay(job, delaySeconds);
 
   // Return the `timeoutID` to use in `clearTimeout`
-  args.rval().setNumber(PyEventLoop::AsyncHandle::getUniqueId(std::move(handle)));
+  args.rval().setNumber(handler.first);
   return true;
 }
 

--- a/tests/python/test_event_loop.py
+++ b/tests/python/test_event_loop.py
@@ -21,9 +21,10 @@ def test_set_clear_timeout():
         def to_raise(msg):
             f1.set_exception(TypeError(msg))
         timeout_id0 = pm.eval("setTimeout")(to_raise, 100, "going to be there")
-        assert type(timeout_id0) == float
-        assert timeout_id0 > 0                  # `setTimeout` should return a positive integer value
-        assert int(timeout_id0) == timeout_id0
+        # `setTimeout` should return a `Timeout` instance wrapping a positive integer value
+        assert pm.eval("(t) => t instanceof setTimeout.Timeout")(timeout_id0)
+        assert pm.eval("(t) => Number(t) > 0")(timeout_id0)
+        assert pm.eval("(t) => Number.isInteger(Number(t))")(timeout_id0)
         with pytest.raises(TypeError, match="going to be there"):
             await f1                                # `clearTimeout` not called
         f1 = loop.create_future()


### PR DESCRIPTION
* implement Node.js-style `Timeout` class (It can be [coerced](https://github.com/Distributive-Network/PythonMonkey/pull/294/files#diff-ca51878c52f36c3c60817c6985d3b4db4201d2f29b04a986b928baeb76419354R29-R35) into a pure `number` by `+timeoutId` or `Number(timeoutId)`.)
* implement [timers `.ref()`/`.unref()` functions](https://nodejs.org/api/timers.html#timeouthasref)