### PR TITLE
Python Trace supplement: Full JS stack trace details

### DIFF
--- a/include/setSpiderMonkeyException.hh
+++ b/include/setSpiderMonkeyException.hh
@@ -18,8 +18,9 @@
  *
  * @param cx - pointer to the JS context
  * @param exceptionStack - reference to the SpiderMonkey exception stack
+ * @param printStack - whether or not to print the JS stack
  */
-PyObject *getExceptionString(JSContext *cx, const JS::ExceptionStack &exceptionStack);
+PyObject *getExceptionString(JSContext *cx, const JS::ExceptionStack &exceptionStack, bool printStack);
 
 /**
  * @brief This function sets a python error under the assumption that a JS_* function call has failed. Do not call this function if that is not the case.

--- a/src/ExceptionType.cc
+++ b/src/ExceptionType.cc
@@ -276,7 +276,7 @@ JSObject *ExceptionType::toJsError(JSContext *cx, PyObject *exceptionValue, PyOb
     Py_XDECREF(code);
   }
 
-  // gather additional JS context
+  // gather additional JS context details
   JS::ErrorReportBuilder reportBuilder(cx);
   if (!reportBuilder.init(cx, exceptionStack, JS::ErrorReportBuilder::WithSideEffects)) {
     return NULL;

--- a/src/ExceptionType.cc
+++ b/src/ExceptionType.cc
@@ -89,7 +89,7 @@ JSObject *ExceptionType::toJsError(JSContext *cx, PyObject *exceptionValue, PyOb
   JS_ClearPendingException(cx);
 
   std::stringstream stackStream;
-  JS::HandleObject stackObj = exceptionStack.stack();
+  JS::RootedObject stackObj(cx, exceptionStack.stack();
   if (stackObj) {
     JS::RootedString stackStr(cx);
     JS::BuildStackString(cx, nullptr, stackObj, &stackStr, 2, js::StackFormat::SpiderMonkey);

--- a/src/ExceptionType.cc
+++ b/src/ExceptionType.cc
@@ -27,7 +27,7 @@ ExceptionType::ExceptionType(JSContext *cx, JS::HandleObject error) {
   // Convert the JS Error object to a Python string
   JS::RootedValue errValue(cx, JS::ObjectValue(*error)); // err
   JS::RootedObject errStack(cx, JS::ExceptionStackOrNull(error)); // err.stack
-  PyObject *errStr = getExceptionString(cx, JS::ExceptionStack(cx, errValue, errStack));
+  PyObject *errStr = getExceptionString(cx, JS::ExceptionStack(cx, errValue, errStack), true);
 
   // Construct a new SpiderMonkeyError python object
   //    pyObject = SpiderMonkeyError(errStr)

--- a/src/ExceptionType.cc
+++ b/src/ExceptionType.cc
@@ -89,8 +89,8 @@ JSObject *ExceptionType::toJsError(JSContext *cx, PyObject *exceptionValue, PyOb
   JS_ClearPendingException(cx);
 
   std::stringstream stackStream;
-  JS::RootedObject stackObj(cx, exceptionStack.stack();
-  if (stackObj) {
+  JS::RootedObject stackObj(cx, exceptionStack.stack());
+  if (stackObj.get()) {
     JS::RootedString stackStr(cx);
     JS::BuildStackString(cx, nullptr, stackObj, &stackStr, 2, js::StackFormat::SpiderMonkey);
     stackStream << "\nJS Stack Trace:\n" << StrType(cx, stackStr).getValue();

--- a/src/ExceptionType.cc
+++ b/src/ExceptionType.cc
@@ -93,7 +93,7 @@ JSObject *ExceptionType::toJsError(JSContext *cx, PyObject *exceptionValue, PyOb
   if (stackObj.get()) {
     JS::RootedString stackStr(cx);
     JS::BuildStackString(cx, nullptr, stackObj, &stackStr, 2, js::StackFormat::SpiderMonkey);
-    stackStream << "\nJS Stack Trace:\n" << StrType(cx, stackStr).getValue();
+    stackStream << "JS Stack Trace:\n" << StrType(cx, stackStr).getValue();
   }
 
 

--- a/src/ExceptionType.cc
+++ b/src/ExceptionType.cc
@@ -290,6 +290,7 @@ JSObject *ExceptionType::toJsError(JSContext *cx, PyObject *exceptionValue, PyOb
   JS::RootedValue rval(cx);
   JS::RootedString filename(cx, JS_NewStringCopyZ(cx, "")); // cannot be null or omitted, but is overriden by the errorReport
   JS::RootedString message(cx, JS_NewStringCopyZ(cx, msgStream.str().c_str()));
+  // filename cannot be null
   if (!JS::CreateError(cx, JSExnType::JSEXN_ERR, nullptr, filename, 0, 0, errorReport, message, JS::NothingHandleValue, &rval)) {
     return NULL;
   }

--- a/src/ExceptionType.cc
+++ b/src/ExceptionType.cc
@@ -12,6 +12,7 @@
 #include "include/setSpiderMonkeyException.hh"
 
 #include "include/ExceptionType.hh"
+#include "include/StrType.hh"
 
 #include <jsapi.h>
 #include <js/Exception.h>
@@ -78,6 +79,25 @@ tb_print_line_repeated(_PyUnicodeWriter *writer, long cnt)
 JSObject *ExceptionType::toJsError(JSContext *cx, PyObject *exceptionValue, PyObject *traceBack) {
   assert(exceptionValue != NULL);
 
+  // Gather JS context
+  JS_ReportErrorASCII(cx, ""); // throw JS error and gather all details
+
+  JS::ExceptionStack exceptionStack(cx);
+  if (!JS::GetPendingExceptionStack(cx, &exceptionStack)) {
+    return NULL;
+  }
+  JS_ClearPendingException(cx);
+
+  std::stringstream stackStream;
+  JS::HandleObject stackObj = exceptionStack.stack();
+  if (stackObj) {
+    JS::RootedString stackStr(cx);
+    JS::BuildStackString(cx, nullptr, stackObj, &stackStr, 2, js::StackFormat::SpiderMonkey);
+    stackStream << "\nJS Stack Trace:\n" << StrType(cx, stackStr).getValue();
+  }
+
+
+  // Gather Python context
   PyObject *pyErrType = PyObject_Type(exceptionValue);
   const char *pyErrTypeName = _PyType_Name((PyTypeObject *)pyErrType);
 
@@ -235,12 +255,12 @@ JSObject *ExceptionType::toJsError(JSContext *cx, PyObject *exceptionValue, PyOb
     {
       std::stringstream msgStream;
       msgStream << "Python " << pyErrTypeName << ": " << PyUnicode_AsUTF8(pyErrMsg) << "\n" << PyUnicode_AsUTF8(_PyUnicodeWriter_Finish(&writer));
-      std::string msg = msgStream.str();
+      msgStream << stackStream.str();
 
       JS::RootedValue rval(cx);
       JS::RootedString filename(cx, JS_NewStringCopyZ(cx, PyUnicode_AsUTF8(fileName)));
-      JS::RootedString message(cx, JS_NewStringCopyZ(cx, msg.c_str()));
-      // TODO stack argument cannot be passed in as a string anymore (deprecated), and could not find a proper example using the new argument type
+      JS::RootedString message(cx, JS_NewStringCopyZ(cx, msgStream.str().c_str()));
+      // stack argument cannot be passed in as a string anymore (deprecated), and could not find a proper example using the new argument type
       if (!JS::CreateError(cx, JSExnType::JSEXN_ERR, nullptr, filename, lineno, 0, nullptr, message, JS::NothingHandleValue, &rval)) {
         return NULL;
       }
@@ -256,15 +276,21 @@ JSObject *ExceptionType::toJsError(JSContext *cx, PyObject *exceptionValue, PyOb
     Py_XDECREF(code);
   }
 
+  // gather additional JS context
+  JS::ErrorReportBuilder reportBuilder(cx);
+  if (!reportBuilder.init(cx, exceptionStack, JS::ErrorReportBuilder::WithSideEffects)) {
+    return NULL;
+  }
+  JSErrorReport *errorReport = reportBuilder.report();
+
   std::stringstream msgStream;
   msgStream << "Python " << pyErrTypeName << ": " << PyUnicode_AsUTF8(pyErrMsg);
-  std::string msg = msgStream.str();
+  msgStream << stackStream.str();
 
   JS::RootedValue rval(cx);
-  JS::RootedObject stack(cx);
-  JS::RootedString filename(cx, JS_NewStringCopyZ(cx, "[python code]"));
-  JS::RootedString message(cx, JS_NewStringCopyZ(cx, msg.c_str()));
-  if (!JS::CreateError(cx, JSExnType::JSEXN_ERR, nullptr, filename, 0, 0, nullptr, message, JS::NothingHandleValue, &rval)) {
+  JS::RootedString filename(cx, JS_NewStringCopyZ(cx, "")); // cannot be null or omitted, but is overriden by the errorReport
+  JS::RootedString message(cx, JS_NewStringCopyZ(cx, msgStream.str().c_str()));
+  if (!JS::CreateError(cx, JSExnType::JSEXN_ERR, nullptr, filename, 0, 0, errorReport, message, JS::NothingHandleValue, &rval)) {
     return NULL;
   }
 

--- a/src/jsTypeFactory.cc
+++ b/src/jsTypeFactory.cc
@@ -288,7 +288,7 @@ void setPyException(JSContext *cx) {
   }
 
   PyObject *type, *value, *traceback;
-  PyErr_Fetch(&type, &value, &traceback); // also clears the error indicator
+  PyErr_Fetch(&type, &value, &traceback);
 
   JSObject *jsException = ExceptionType::toJsError(cx, value, traceback);
 

--- a/src/setSpiderMonkeyException.cc
+++ b/src/setSpiderMonkeyException.cc
@@ -83,27 +83,19 @@ void setSpiderMonkeyException(JSContext *cx) {
   }
 
   // check if it is a Python Exception and already has a stack trace
-  bool printStack;
+  bool printStack = true;
 
-  JS::Rooted<JS::Value> exn(cx);
+  JS::RootedValue exn(cx);
   JS_GetPendingException(cx, &exn);
   if (exn.isObject()) {
     JS::RootedObject exnObj(cx, &exn.toObject());
     JS::RootedValue tmp(cx);
-    if (!JS_GetProperty(cx, exnObj, "message", &tmp)) {
-      printStack = true;
-    }
-    else if (tmp.isString()) {
+    if (JS_GetProperty(cx, exnObj, "message", &tmp) && tmp.isString()) {
       JS::RootedString rootedStr(cx, tmp.toString());
       printStack = strstr(JS_EncodeStringToUTF8(cx, rootedStr).get(), "JS Stack Trace") == NULL;
     }
-    else {
-      printStack = true;
-    }
   }
-  else {
-    printStack = true;
-  }
+
 
   JS_ClearPendingException(cx);
 

--- a/src/setSpiderMonkeyException.cc
+++ b/src/setSpiderMonkeyException.cc
@@ -60,8 +60,8 @@ PyObject *getExceptionString(JSContext *cx, const JS::ExceptionStack &exceptionS
     JS::RootedObject stackObj(cx, exceptionStack.stack());
     if (stackObj.get()) {
       JS::RootedString stackStr(cx);
-      BuildStackString(cx, nullptr, stackObj, &stackStr, /* indent */ 2, js::StackFormat::SpiderMonkey);
-      outStrStream << "Stack Trace: \n" << StrType(cx, stackStr).getValue();
+      BuildStackString(cx, nullptr, stackObj, &stackStr, 2, js::StackFormat::SpiderMonkey);
+      outStrStream << "Stack Trace:\n" << StrType(cx, stackStr).getValue();
     }
   }
 
@@ -95,7 +95,6 @@ void setSpiderMonkeyException(JSContext *cx) {
       printStack = strstr(JS_EncodeStringToUTF8(cx, rootedStr).get(), "JS Stack Trace") == NULL;
     }
   }
-
 
   JS_ClearPendingException(cx);
 

--- a/src/setSpiderMonkeyException.cc
+++ b/src/setSpiderMonkeyException.cc
@@ -56,8 +56,9 @@ PyObject *getExceptionString(JSContext *cx, const JS::ExceptionStack &exceptionS
   // print out the SpiderMonkey error message
   outStrStream << reportBuilder.toStringResult().c_str() << "\n";
 
-  JS::HandleObject stackObj = exceptionStack.stack();
-  if (stackObj) { // stack can be null
+
+  JS::RootedObject stackObj(cx, exceptionStack.stack());
+  if (stackObj.get()) {
     JS::RootedString stackStr(cx);
     BuildStackString(cx, nullptr, stackObj, &stackStr, /* indent */ 2, js::StackFormat::SpiderMonkey);
     outStrStream << "Stack Trace: \n" << StrType(cx, stackStr).getValue();

--- a/src/setSpiderMonkeyException.cc
+++ b/src/setSpiderMonkeyException.cc
@@ -86,13 +86,14 @@ void setSpiderMonkeyException(JSContext *cx) {
   bool printStack = true;
 
   JS::RootedValue exn(cx);
-  JS_GetPendingException(cx, &exn);
-  if (exn.isObject()) {
-    JS::RootedObject exnObj(cx, &exn.toObject());
-    JS::RootedValue tmp(cx);
-    if (JS_GetProperty(cx, exnObj, "message", &tmp) && tmp.isString()) {
-      JS::RootedString rootedStr(cx, tmp.toString());
-      printStack = strstr(JS_EncodeStringToUTF8(cx, rootedStr).get(), "JS Stack Trace") == NULL;
+  if (JS_GetPendingException(cx, &exn)) {
+    if (exn.isObject()) {
+      JS::RootedObject exnObj(cx, &exn.toObject());
+      JS::RootedValue tmp(cx);
+      if (JS_GetProperty(cx, exnObj, "message", &tmp) && tmp.isString()) {
+        JS::RootedString rootedStr(cx, tmp.toString());
+        printStack = strstr(JS_EncodeStringToUTF8(cx, rootedStr).get(), "JS Stack Trace") == NULL;
+      }
     }
   }
 

--- a/tests/python/test_arrays.py
+++ b/tests/python/test_arrays.py
@@ -754,7 +754,12 @@ def test_sort_with_two_args_keyfunc_wrong_data_type():
         assert (False)
     except Exception as e:    
         assert str(type(e)) == "<class 'pythonmonkey.SpiderMonkeyError'>"
-        assert "object of type 'float' has no len()" in str(e)   
+        assert "object of type 'float' has no len()" in str(e)  
+        assert "test_arrays.py" in str(e)   
+        assert "line 751" in str(e)  
+        assert "in myFunc" in str(e) 
+        assert "JS Stack Trace" in str(e) 
+        assert "@evaluate:1:27" in str(e) 
 
 def test_sort_with_one_arg_keyfunc():
     items = ['Four', 'Three', 'One']   
@@ -766,6 +771,8 @@ def test_sort_with_one_arg_keyfunc():
     except Exception as e:    
         assert str(type(e)) == "<class 'pythonmonkey.SpiderMonkeyError'>"
         assert "takes 1 positional argument but 2 were given" in str(e)
+        assert "JS Stack Trace" in str(e) 
+        assert "@evaluate:1:27" in str(e)  
 
 def test_sort_with_builtin_keyfunc():
     items = ['Four', 'Three', 'One']   
@@ -774,7 +781,9 @@ def test_sort_with_builtin_keyfunc():
         assert (False)
     except Exception as e:  
         assert str(type(e)) == "<class 'pythonmonkey.SpiderMonkeyError'>"
-        assert "len() takes exactly one argument (2 given)" in str(e)    
+        assert "len() takes exactly one argument (2 given)" in str(e)
+        assert "JS Stack Trace" in str(e) 
+        assert "@evaluate:1:27" in str(e)      
 
 def test_sort_with_js_func():
     items = ['Four', 'Three', 'One']  


### PR DESCRIPTION
Addendum to https://github.com/Distributive-Network/PythonMonkey/pull/286

Provide Full JS context when catch a Python Exception happening in a JS context