### PR TITLE
Fix(console): extra stack property is printed after the stack trace

### DIFF
--- a/python/pythonmonkey/builtin_modules/util.js
+++ b/python/pythonmonkey/builtin_modules/util.js
@@ -533,8 +533,9 @@ function formatValue(ctx, value, recurseTimes, ln) {
       base = ` ${dateToISOString.call(value)}`;
     } else if (isError(value)) {
       // Make error with message first say the error
-      if (keyLength === 0)
+      if (keyLength === 0 || keys.every(k => k === 'stack')) // There's only a 'stack' property
         return formatError(ctx, value);
+      keys = keys.filter(k => k !== 'stack'); // When changing the 'stack' property in SpiderMonkey, it becomes enumerable.
       base = ` ${formatError(ctx, value)}\n`;
       braces.length=0;
     } else if (isAnyArrayBuffer(value)) {

--- a/tests/js/util-module.simple
+++ b/tests/js/util-module.simple
@@ -1,0 +1,20 @@
+/**
+ * @file        util-module.simple
+ *              Simple test for the builtin util module
+ * @author      Tom Tang <xmader@distributive.network>
+ * @date        March 2024
+ */
+
+const util = require('util');
+
+// https://github.com/Distributive-Network/PythonMonkey/pull/300
+const err = new TypeError();
+if (err.propertyIsEnumerable('stack'))
+  throw new Error('The stack property should not be enumerable.');
+err.anything = 123;
+err.stack = 'abc';
+if (!err.propertyIsEnumerable('stack'))
+  throw new Error('In SpiderMonkey, the stack property should be enumerable after changing it.');
+const output = util.format(err);
+if (output.match(/abc/g).length !== 1) // should only be printed once
+  throw new Error('The stack property should not be printed along with other enumerable properties');


### PR DESCRIPTION
The `util.format` code [looks up all its own enumerable properties](https://github.com/Distributive-Network/PythonMonkey/blob/4901d0b/python/pythonmonkey/builtin_modules/util.js#L443) by `Object.keys()` then prints them out.

In SpiderMonkey, when changing the `stack` property of an `Error` object, `stack` becomes an enumerable property, while V8 doesn't. Our `util.inspect`/`util.format` code was copied from Node.js, so it won't handle the difference.

According to https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/stack#value, the `stack` property is implementation dependent.