### PR TITLE
VSCode Debugger Fast Build

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,7 +17,7 @@
           "run"
         ],
       },
-      "preLaunchTask": "Build",
+      "preLaunchTask": "Fast build",
       "cwd": "${fileDirname}",
       "environment": [],
       "externalConsole": false,

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -26,6 +26,22 @@
         "isDefault": true
       }
     },
+    {
+      "label": "Fast build",
+      "type": "process",
+      "command": "poetry",
+      "args": [
+        "run",
+        "python",
+        "./build.py",
+      ],
+      "problemMatcher": [
+        "$gcc"
+      ],
+      "group": {
+        "kind": "build",
+      }
+    },
     // 
     // Test
     // 


### PR DESCRIPTION
This PR changes the VSCode visual debugger's `preLaunchTask` to only run `build.py`.
This avoids wasting time by trying to update dependencies by `poetry install`.