### PR TITLE
HOTFIX: `.unref()` not working on `setInterval` timers

### DIFF
--- a/src/JobQueue.cc
+++ b/src/JobQueue.cc
@@ -114,7 +114,7 @@ bool sendJobToMainLoop(PyObject *pyFunc) {
 
   PyGILState_Release(gstate);
   return true;
-}  
+}
 
 void JobQueue::queueFinalizationRegistryCallback(JSFunction *callback) {
   mozilla::Unused << finalizationRegistryCallbacks->append(callback);

--- a/src/PyEventLoop.cc
+++ b/src/PyEventLoop.cc
@@ -80,7 +80,6 @@ static PyObject *_enqueueWithDelay(PyObject *_loop, PyEventLoop::AsyncHandle::id
 
   auto handle = PyEventLoop::AsyncHandle::fromId(handleId);
   Py_XDECREF(handle->swap(asyncHandle));
-  handle->addRef();
 
   return asyncHandle;
 }
@@ -90,6 +89,8 @@ PyEventLoop::AsyncHandle::id_t PyEventLoop::enqueueWithDelay(PyObject *jobFn, do
   if (!_enqueueWithDelay(_loop, handleId, jobFn, delaySeconds, repeat)) {
     PyErr_Print(); // RuntimeError: Non-thread-safe operation invoked on an event loop other than the current one
   }
+  auto handle = PyEventLoop::AsyncHandle::fromId(handleId);
+  handle->addRef();
   return handleId;
 }
 

--- a/src/internalBinding/utils.cc
+++ b/src/internalBinding/utils.cc
@@ -2,7 +2,7 @@
  * @file utils.cc
  * @author Tom Tang (xmader@distributive.network)
  * @brief Implement functions in `internalBinding("utils")`
- * 
+ *
  * @copyright Copyright (c) 2023 Distributive Corp.
  */
 

--- a/tests/python/test_event_loop.py
+++ b/tests/python/test_event_loop.py
@@ -2,7 +2,7 @@ import pytest
 import pythonmonkey as pm
 import asyncio
 
-def test_timers_unref():
+def test_setTimeout_unref():
     async def async_fn():
         obj = {'val': 0}
         pm.eval("""(obj) => {
@@ -14,6 +14,18 @@ def test_timers_unref():
         assert obj['val'] == 1
 
         # making sure the async_fn is run
+        return True
+    assert asyncio.run(async_fn())
+
+def test_setInterval_unref():
+    async def async_fn():
+        obj = {'val': 0}
+        pm.eval("""(obj) => {
+            setInterval(()=>{ obj.val++ }, 200).unref()
+            setTimeout(()=>{ }, 500)
+        }""")(obj)
+        await pm.wait() # It should stop after the setTimeout timer's 500ms.
+        assert obj['val'] == 2 # The setInterval timer should only run twice (500 // 200 == 2)
         return True
     assert asyncio.run(async_fn())
 


### PR DESCRIPTION
```js
setInterval(()=>console.log(123), 200).unref()
setTimeout(()=>console.log(5), 500)
```

It should stop after 500ms