### PR TITLE
DEBUG symbols separated by comma instead of space for consistency

### DIFF
--- a/python/pythonmonkey/require.py
+++ b/python/pythonmonkey/require.py
@@ -161,7 +161,7 @@ bootstrap.modules.debug = function debug(selector)
 
   if (debugEnv)
   {
-    for (let sym of debugEnv.split(' '))
+    for (let sym of debugEnv.split(','))
     {
       const re = new RegExp('^' + sym.replace('*', '.*') + '$');
       if (re.test(selector))


### PR DESCRIPTION
DEBUG var usage now consistent with usage of the DCP_DEBUG var in DCP