### PR TITLE
chore(meta): update minimum pminit version in poetry.lock

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -705,7 +705,7 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "pminit"
-version = "0.3.1.dev37+f1e980c"
+version = "0.5.1.dev152+7b661a4"
 description = "Post-install hook for PythonMonkey"
 optional = false
 python-versions = "^3.8"
@@ -943,4 +943,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "c246eb1c36e99b5e0ae61277ac3f0a2404a3dfbcfbaa61ef5b5fef0fd8cbe443"
+content-hash = "11d3704623455cf65a35174a88b275bb80ab36ae0dc95074b1a943ef0be3c08d"

--- a/poetry.lock
+++ b/poetry.lock
@@ -704,19 +704,6 @@ dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
-name = "pminit"
-version = "0.5.1.dev152+7b661a4"
-description = "Post-install hook for PythonMonkey"
-optional = false
-python-versions = "^3.8"
-files = []
-develop = true
-
-[package.source]
-type = "directory"
-url = "python/pminit"
-
-[[package]]
 name = "pycares"
 version = "4.4.0"
 description = "Python interface for c-ares"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ include = [
 python = "^3.8"
 pyreadline3 = { version = "^3.4.1", platform = "win32" }
 aiohttp = { version = "^3.9.5", extras = ["speedups"] }
-pminit = { version = "*", allow-prereleases = true }
+pminit = { version = ">=0.4.0", allow-prereleases = true }
 
 
 [tool.poetry-dynamic-versioning]


### PR DESCRIPTION
This PR updates the minimum required version of pminit to 0.4.0, so that when users upgrade their installation of pythonmonkey with `pip install pythonmonkey --upgrade`, core-js will be available even if the user has an old version of pminit that pre-dates our inclusion of core-js.

addresses #185 once we publish a new release