### PR TITLE
HOTFIX: `clearInterval` won't unref the timer sometimes

### DIFF
--- a/src/internalBinding/timers.cc
+++ b/src/internalBinding/timers.cc
@@ -59,6 +59,7 @@ static bool cancelByTimeoutId(JSContext *cx, unsigned argc, JS::Value *vp) {
 
   // Cancel this job on the Python event-loop
   handle->cancel();
+  handle->removeRef();
 
   return true;
 }

--- a/tests/python/test_event_loop.py
+++ b/tests/python/test_event_loop.py
@@ -37,10 +37,10 @@ def test_clearInterval():
     obj = {'val': 0}
     pm.eval("""(obj) => {
             const interval = setInterval(()=>{ obj.val++ }, 200)
-            setTimeout(()=>{ clearInterval(interval) }, 400)
+            setTimeout(()=>{ clearInterval(interval) }, 500)
         }""")(obj)
-    await pm.wait()  # It should stop after 400ms on the clearInterval
-    assert obj['val'] == 2  # The setInterval timer should only run twice (400 // 200 == 2)
+    await pm.wait()  # It should stop after 500ms on the clearInterval
+    assert obj['val'] == 2  # The setInterval timer should only run twice (500 // 200 == 2)
     return True
   assert asyncio.run(async_fn())
 

--- a/tests/python/test_event_loop.py
+++ b/tests/python/test_event_loop.py
@@ -32,6 +32,19 @@ def test_setInterval_unref():
   assert asyncio.run(async_fn())
 
 
+def test_clearInterval():
+  async def async_fn():
+    obj = {'val': 0}
+    pm.eval("""(obj) => {
+            const interval = setInterval(()=>{ obj.val++ }, 200)
+            setTimeout(()=>{ clearInterval(interval) }, 400)
+        }""")(obj)
+    await pm.wait()  # It should stop after 400ms on the clearInterval
+    assert obj['val'] == 2  # The setInterval timer should only run twice (400 // 200 == 2)
+    return True
+  assert asyncio.run(async_fn())
+
+
 def test_finished_timer_ref():
   async def async_fn():
     # Making sure the event-loop won't be activated again when a finished timer gets re-refed.


### PR DESCRIPTION
We were only calling `removeRef` after the timer's job function is run. https://github.com/Distributive-Network/PythonMonkey/blob/08b923c08752bed58d94f9d6bf84dae08cc7d093/src/PyEventLoop.cc#L54
However, when a interval timer gets cancelled between its runs, the job function won't run, thus the timer won't be automatically unref'ed.