### PR TITLE
Add back JavaScript files to Doxygen-generated docs

### DIFF
--- a/cmake/docs/Doxyfile.in
+++ b/cmake/docs/Doxyfile.in
@@ -19,8 +19,8 @@ GENERATE_XML = YES
 OPTIMIZE_OUTPUT_JAVA = YES
 STRIP_FROM_PATH = "@CMAKE_SOURCE_DIR@"
 
-FILE_PATTERNS = *.cc *.hh *.py *.pyi *.md
-EXTENSION_MAPPING = pyi=python
+FILE_PATTERNS = *.cc *.hh *.py *.pyi *.js *.ts *.md
+EXTENSION_MAPPING = pyi=python js=javascript ts=javascript
 
 # Doxygen Theme
 # https://jothepro.github.io/doxygen-awesome-css/


### PR DESCRIPTION
JavaScript is actually supported by Doxygen

In https://www.doxygen.nl/manual/config.html `EXTENSION_MAPPING`
> ... language is one of the parsers supported by doxygen: IDL, Java, JavaScript, Csharp (C#), C, C++, Lex, D, PHP, md (Markdown), Objective-C, Python, Slice, VHDL, Fortran

And I could verify it working by looking at the generated `Class List` page.

This reverts commit ea30c367c7ca5b5bee39905ad091275acff18354 "chore(docs): JavaScript is not support by Doxygen".

Actually I added JavaScript on purpose in commit c89a67fc50788799833f299362e3000df4822b84.