### PR TITLE
CI: remove redundant macOS 13 CI runs to save the limit of concurrent macOS CI jobs

### DIFF
--- a/.github/workflows/test-and-publish.yaml
+++ b/.github/workflows/test-and-publish.yaml
@@ -17,7 +17,6 @@ on:
         - ''
         - 'ubuntu-20.04'
         - 'macos-12'
-        - 'macos-13'
         - 'macos-14'
         - 'windows-2019'
       debug_enabled_python:
@@ -124,7 +123,7 @@ jobs:
       fail-fast: false
       matrix:
         # The lowest supported version is Ubuntu 20.04 + Python 3.8 or macOS 12 + Python 3.9
-        os: [ 'ubuntu-20.04', 'macos-12', 'macos-13', 'macos-14', 'windows-2019' ]
+        os: [ 'ubuntu-20.04', 'macos-12', 'macos-14', 'windows-2019' ]
         python_version: [ '3.8', '3.9', '3.10', '3.11', '3.12' ]
         exclude:
           # macOS 12 comes with Python 3.9 by default, so we drop ci support for Python 3.8 on macOS


### PR DESCRIPTION
GitHub limits the number of concurrent macOS runners to 5. 
macOS 13 CI runs here are redundant since our binary files built for macos-12 are forward-compatible on macos-13.

I was putting both macos-12 and macos-14 tags here just in order to build on both amd64 and arm64 (macos-14 exclusively) architectures than to differentiate the OS versions. https://github.com/Distributive-Network/PythonMonkey/commit/c402def