### PR TITLE
Change the build task for VSCode to build in Debug mode

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -38,6 +38,11 @@
       "problemMatcher": [
         "$gcc"
       ],
+      "options": {
+        "env": {
+          "BUILD_TYPE": "Debug"
+        }
+      },
       "group": {
         "kind": "build",
       }


### PR DESCRIPTION
The `Fast Build` task should build in Debug as it's supposed to run from the VSCode visual debugger.