### PR TITLE
Do not print the internal implementation line in the console trace method

### DIFF
--- a/python/pythonmonkey/builtin_modules/console.js
+++ b/python/pythonmonkey/builtin_modules/console.js
@@ -99,7 +99,8 @@ class Console
         ? `Trace: ${format(...args)}\n`
         : 'Trace\n';
 
-      let stacks = new Error().stack.split('\n')
+      let stacks = new Error().stack
+            .split('\n')
       stacks.shift();              // skip the first line which is this.trace itself
       stacks = stacks
             .filter(s => s !== '') // filter out empty lines

--- a/python/pythonmonkey/builtin_modules/console.js
+++ b/python/pythonmonkey/builtin_modules/console.js
@@ -98,11 +98,13 @@ class Console
       const header = args.length > 0
         ? `Trace: ${format(...args)}\n`
         : 'Trace\n';
-      const stacks = new Error().stack
-        .split('\n')
-        .filter(s => s !== '') // filter out empty lines
-        .map(s => '    '+s)    // add indent
-        .join('\n');
+
+      let stacks = new Error().stack.split('\n')
+      stacks.shift();              // skip the first line which is this.trace itself
+      stacks = stacks
+            .filter(s => s !== '') // filter out empty lines
+            .map(s => '    '+s)    // add indent
+            .join('\n');
       return this.debug(header + stacks);
     };
 

--- a/tests/js/console-methods.simple
+++ b/tests/js/console-methods.simple
@@ -73,6 +73,7 @@ expectOutput('stderr', /^Assertion failed: abc undefined$/m, (console) => consol
 expectOutput('stdout', /^Trace\n/, (console) => console.trace());
 expectOutput('stdout', /^Trace: \x1b\[90mundefined\x1b\[39m\n/, (console) => console.trace(undefined));
 expectOutput('stdout', /^Trace: \x1b\[33m123\x1b\[39m\n/, (console) => console.trace(123));
+expectOutput('stdout', /^((?!console\.js)[\s\S])*$/, (console) => console.trace());  // implementation details should not show up in the trace
 
 // console.count()
 let keptConsole;


### PR DESCRIPTION
Console.trace's own context should not be printed in the output but it is now:

With 
import pythonmonkey as pm
pm.eval('function foo(){ function bar() { console.trace() } bar(); } foo();')

get

Trace
_home_philippe_Sources_PythonMonkey_python_pythonmonkey_builtin_modules_console_js/Console/this.trace@/home/philippe/Sources/PythonMonkey/python/pythonmonkey/builtin_modules/console.js:104:22
    bar@evaluate:1:42
    foo@evaluate:1:52
     @evaluate:1:61
    
Now fixed to 

import pythonmonkey as pm
pm.eval('function foo(){ function bar() { console.trace() } bar(); } foo();')

gets

Trace
    bar@evaluate:1:42
    foo@evaluate:1:52
     @evaluate:1:61


    