### PR TITLE
fix python function arg-count mismatch frustration

### DIFF
--- a/src/jsTypeFactory.cc
+++ b/src/jsTypeFactory.cc
@@ -331,10 +331,11 @@ bool callPyFunc(JSContext *cx, unsigned int argc, JS::Value *vp) {
   bool unknownNargs = false;
 
   if (PyCFunction_Check(pyFunc)) {
-    if (((PyCFunctionObject *)pyFunc)->m_ml->ml_flags & METH_NOARGS) { // 0 arguments
+    const int funcFlags = ((PyCFunctionObject *)pyFunc)->m_ml->ml_flags;
+    if (funcFlags & METH_NOARGS) { // 0 arguments
       nNormalArgs = 0;
     }
-    else if (((PyCFunctionObject *)pyFunc)->m_ml->ml_flags & METH_O) { // 1 argument
+    else if (funcFlags & METH_O) { // 1 argument
       nNormalArgs = 1;
     }
     else { // unknown number of arguments

--- a/tests/python/test_arrays.py
+++ b/tests/python/test_arrays.py
@@ -894,33 +894,6 @@ def test_sort_with_two_args_keyfunc_wrong_data_type():
     assert "@evaluate:1:27" in str(e)
 
 
-def test_sort_with_one_arg_keyfunc():
-  items = ['Four', 'Three', 'One']
-
-  def myFunc(e):
-    return len(e)
-  try:
-    pm.eval("(arr, compareFun) => {arr.sort(compareFun)}")(items, myFunc)
-    assert (False)
-  except Exception as e:
-    assert str(type(e)) == "<class 'pythonmonkey.SpiderMonkeyError'>"
-    assert "takes 1 positional argument but 2 were given" in str(e)
-    assert "JS Stack Trace" in str(e)
-    assert "@evaluate:1:27" in str(e)
-
-
-def test_sort_with_builtin_keyfunc():
-  items = ['Four', 'Three', 'One']
-  try:
-    pm.eval("(arr, compareFun) => {arr.sort(compareFun)}")(items, len)
-    assert (False)
-  except Exception as e:
-    assert str(type(e)) == "<class 'pythonmonkey.SpiderMonkeyError'>"
-    assert "len() takes exactly one argument (2 given)" in str(e)
-    assert "JS Stack Trace" in str(e)
-    assert "@evaluate:1:27" in str(e)
-
-
 def test_sort_with_js_func():
   items = ['Four', 'Three', 'One']
   result = [None]

--- a/tests/python/test_functions.py
+++ b/tests/python/test_functions.py
@@ -1,0 +1,121 @@
+import pythonmonkey as pm
+
+
+def test_func_no_args():
+  def f():
+    return 42
+  assert 42 == pm.eval("(f) => f()")(f)
+
+
+def test_func_too_many_args():
+  def f(a, b):
+    return [a, b]
+  assert [1, 2] == pm.eval("(f) => f(1, 2, 3)")(f)
+
+
+def test_func_equal_args():
+  def f(a, b):
+    return [a, b]
+  assert [1, 2] == pm.eval("(f) => f(1, 2)")(f)
+
+
+def test_func_too_few_args():
+  def f(a, b):
+    return [a, b]
+  assert [1, None] == pm.eval("(f) => f(1)")(f)
+
+
+def test_default_func_no_args():
+  def f(a, b, c=42, d=43):
+    return [a, b, c, d]
+  assert [None, None, 42, 43] == pm.eval("(f) => f()")(f)
+
+
+def test_default_func_too_many_default_args():
+  def f(a, b, c=42, d=43):
+    return [a, b, c, d]
+  assert [1, 2, 3, 4] == pm.eval("(f) => f(1, 2, 3, 4, 5)")(f)
+
+
+def test_default_func_equal_default_args():
+  def f(a, b, c=42, d=43):
+    return [a, b, c, d]
+  assert [1, 2, 3, 4] == pm.eval("(f) => f(1, 2, 3, 4)")(f)
+
+
+def test_default_func_too_few_default_args():
+  def f(a, b, c=42, d=43):
+    return [a, b, c, d]
+  assert [1, 2, 3, 43] == pm.eval("(f) => f(1, 2, 3)")(f)
+
+
+def test_default_func_equal_args():
+  def f(a, b, c=42, d=43):
+    return [a, b, c, d]
+  assert [1, 2, 42, 43] == pm.eval("(f) => f(1, 2)")(f)
+
+
+def test_default_func_too_few_args():
+  def f(a, b, c=42, d=43):
+    return [a, b, c, d]
+  assert [1, None, 42, 43] == pm.eval("(f) => f(1)")(f)
+
+
+def test_vararg_func_no_args():
+  def f(a, b, *args):
+    return [a, b, *args]
+  assert [None, None] == pm.eval("(f) => f()")(f)
+
+
+def test_vararg_func_too_many_args():
+  def f(a, b, *args):
+    return [a, b, *args]
+  assert [1, 2, 3] == pm.eval("(f) => f(1, 2, 3)")(f)
+
+
+def test_vararg_func_equal_args():
+  def f(a, b, *args):
+    return [a, b, *args]
+  assert [1, 2] == pm.eval("(f) => f(1, 2)")(f)
+
+
+def test_vararg_func_too_few_args():
+  def f(a, b, *args):
+    return [a, b, *args]
+  assert [1, None] == pm.eval("(f) => f(1)")(f)
+
+
+def test_default_vararg_func_no_args():
+  def f(a, b, c=42, d=43, *args):
+    return [a, b, c, d, *args]
+  assert [None, None, 42, 43] == pm.eval("(f) => f()")(f)
+
+
+def test_default_vararg_func_too_many_default_args():
+  def f(a, b, c=42, d=43, *args):
+    return [a, b, c, d, *args]
+  assert [1, 2, 3, 4, 5] == pm.eval("(f) => f(1, 2, 3, 4, 5)")(f)
+
+
+def test_default_vararg_func_equal_default_args():
+  def f(a, b, c=42, d=43, *args):
+    return [a, b, c, d, *args]
+  assert [1, 2, 3, 4] == pm.eval("(f) => f(1, 2, 3, 4)")(f)
+
+
+def test_default_vararg_func_too_few_default_args():
+  def f(a, b, c=42, d=43, *args):
+    return [a, b, c, d, *args]
+  assert [1, 2, 3, 43] == pm.eval("(f) => f(1, 2, 3)")(f)
+
+
+def test_default_vararg_func_equal_args():
+  def f(a, b, c=42, d=43, *args):
+    return [a, b, c, d, *args]
+  assert [1, 2, 42, 43] == pm.eval("(f) => f(1, 2)")(f)
+
+
+def test_default_vararg_func_too_few_args():
+  def f(a, b, c=42, d=43, *args):
+    return [a, b, c, d, *args]
+  assert [1, None, 42, 43] == pm.eval("(f) => f(1)")(f)


### PR DESCRIPTION
This PR fixes #265, by allowing JS code to call python functions even when supplied too many or too few arguments. 

When too many arguments are supplied, those beyond the function's argument count are ignored, e.g.:
```py
def f(a, b):
  return [a, b]
assert [1, 2] == pm.eval("(f) => f(1, 2, 3)")(f)
```

When too few arguments are supplied, those beyond the number of supplied arguments are passed as `None` to match JavaScript's behaviour of passing `undefined`, e.g.:
```py
def f(a, b):
  return [a, b]
assert [1, None] == pm.eval("(f) => f(1)")(f)
```

This also works for functions with default arguments, or varargs, e.g.:
```py
def f(a, b, c=42, d=43, *args):
  return [a, b, c, d, *args]
assert pm.eval("(f) => f(1, 2, 3, 4, 5)")(f) == [1, 2, 3, 4, 5] 
assert pm.eval("(f) => f(1, 2, 3, 4)")(f) == [1, 2, 3, 4]
assert pm.eval("(f) => f(1, 2, 3)")(f) == [1, 2, 3, 43] 
assert pm.eval("(f) => f(1, 2)")(f) == [1, 2, 42, 43] 
assert pm.eval("(f) => f(1)")(f) == [1, None, 42, 43] 
assert pm.eval("(f) => f()")(f) == [None, None, 42, 43] 
```

This PR potentially has the downside that I outlined [here](https://github.com/Distributive-Network/PythonMonkey/issues/265#issuecomment-1981242000), where programmers primarily familiar with python rather than JS might expect a python function supplied with too many or too few arguments to raise a `TypeError: f() missing X required positional arguments` or `TypeError: f() takes X positional arguments but Y were given` exception like usual, rather than silently adding or removing arguments to the function call.

To keep this relationship symmetrical, we may wish to make it so we raise an exception when a JS function is called with too many or too few arguments from python, despite that not normally being the case in JS.