### PR TITLE
PMJS should run files in script mode, shouldn't try to retrieve the last expression value of the file

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,11 +164,11 @@ They are largely based on SpiderMonkey's `CompileOptions`. The supported option 
 - `filename`: set the filename of this code for the purposes of generating stack traces etc.
 - `lineno`: set the line number offset of this code for the purposes of generating stack traces etc.
 - `column`: set the column number offset of this code for the purposes of generating stack traces etc.
-- `mutedErrors`: experimental
-- `noScriptRval`: experimental
-- `selfHosting`: experimental
-- `strict`: experimental
-- `module`: experimental
+- `mutedErrors`: if set to `True`, eval errors or unhandled rejections are ignored ("muted"). Default `False`.
+- `noScriptRval`: if `False`, return the last expression value of the script as the result value to the caller. Default `False`.
+- `selfHosting`: *experimental*
+- `strict`: forcibly evaluate in strict mode (`"use strict"`). Default `False`.
+- `module`: indicate the file is an ECMAScript module (always strict mode code and disallow HTML comments). Default `False`.
 - `fromPythonFrame`: generate the equivalent of filename, lineno, and column based on the location of
   the Python call to eval. This makes it possible to evaluate Python multiline string literals and
   generate stack traces in JS pointing to the error in the Python source file.

--- a/python/pythonmonkey/require.py
+++ b/python/pythonmonkey/require.py
@@ -409,7 +409,8 @@ def runProgramModule(filename, argv, extraPaths=[]):
   globalThis.__filename = fullFilename
   globalThis.__dirname = os.path.dirname(fullFilename)
   with open(fullFilename, encoding="utf-8", mode="r") as mainModuleSource:
-    pm.eval(mainModuleSource.read(), {'filename': fullFilename})
+    pm.eval(mainModuleSource.read(), {'filename': fullFilename, 'noScriptRval': True})
+    # forcibly run in file mode. We shouldn't be getting the last statement of the script as the result value.
 
 # The pythonmonkey require export. Every time it is used, the stack is inspected so that the filename
 # passed to createRequire is correct. This is necessary so that relative requires work. If the filename

--- a/python/pythonmonkey/require.py
+++ b/python/pythonmonkey/require.py
@@ -410,7 +410,7 @@ def runProgramModule(filename, argv, extraPaths=[]):
   globalThis.__dirname = os.path.dirname(fullFilename)
   with open(fullFilename, encoding="utf-8", mode="r") as mainModuleSource:
     pm.eval(mainModuleSource.read(), {'filename': fullFilename, 'noScriptRval': True})
-    # forcibly run in file mode. We shouldn't be getting the last statement of the script as the result value.
+    # forcibly run in file mode. We shouldn't be getting the last expression of the script as the result value.
 
 # The pythonmonkey require export. Every time it is used, the stack is inspected so that the filename
 # passed to createRequire is correct. This is necessary so that relative requires work. If the filename

--- a/src/pyTypeFactory.cc
+++ b/src/pyTypeFactory.cc
@@ -37,6 +37,8 @@
 #include <js/ValueArray.h>
 
 PyObject *pyTypeFactory(JSContext *cx, JS::HandleValue rval) {
+  std::string errorString;
+
   if (rval.isUndefined()) {
     return NoneType::getPyObject();
   }
@@ -53,7 +55,7 @@ PyObject *pyTypeFactory(JSContext *cx, JS::HandleValue rval) {
     return StrType::getPyObject(cx, rval);
   }
   else if (rval.isSymbol()) {
-    printf("symbol type is not handled by PythonMonkey yet\n");
+    errorString = "symbol type is not handled by PythonMonkey yet.\n";
   }
   else if (rval.isBigInt()) {
     return IntType::getPyObject(cx, rval.toBigInt());
@@ -117,10 +119,10 @@ PyObject *pyTypeFactory(JSContext *cx, JS::HandleValue rval) {
     return DictType::getPyObject(cx, rval);
   }
   else if (rval.isMagic()) {
-    printf("magic type is not handled by PythonMonkey yet\n");
+    errorString = "magic type is not handled by PythonMonkey yet.\n";
   }
 
-  std::string errorString("pythonmonkey cannot yet convert Javascript value of: ");
+  errorString += "pythonmonkey cannot yet convert Javascript value of: ";
   JSString *valToStr = JS::ToString(cx, rval);
   if (!valToStr) { // `JS::ToString` returns `nullptr` for JS symbols, see https://hg.mozilla.org/releases/mozilla-esr102/file/3b574e1/js/src/vm/StringType.cpp#l2208
     // TODO (Tom Tang): Revisit this once we have Symbol coercion support


### PR DESCRIPTION
If the last expression value is a JS type that can't currently be converted to a Python type in PythonMonkey 
(e.g. JS [`Symbol`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol) type), 
`pmjs` should ignore it completely instead of trying to covert it so hard (segfault/error).