### PR TITLE
Add more type hints & documentations for the public API in the `.pyi` stub file

### DIFF
--- a/python/pythonmonkey/pythonmonkey.pyi
+++ b/python/pythonmonkey/pythonmonkey.pyi
@@ -26,6 +26,25 @@ def eval(code: str, evalOpts: EvalOptions = {}, /) -> _typing.Any:
   """
 
 
+def require(moduleIdentifier: str, /) -> JSObjectProxy:
+  """
+  Return the exports of a CommonJS module identified by `moduleIdentifier`, using standard CommonJS semantics
+  """
+
+
+def new(ctor: JSFunctionProxy) -> _typing.Callable[..., _typing.Any]:
+  """
+  Wrap the JS new operator, emitting a lambda which constructs a new
+  JS object upon invocation
+  """
+
+
+def typeof(jsval: _typing.Any, /):
+  """
+  This is the JS `typeof` operator, wrapped in a function so that it can be used easily from Python.
+  """
+
+
 def wait() -> _typing.Awaitable[None]:
   """
   Block until all asynchronous jobs (Promise/setTimeout/etc.) finish.
@@ -41,6 +60,12 @@ def wait() -> _typing.Awaitable[None]:
 def stop() -> None:
   """
   Stop all pending asynchronous jobs, and unblock `await pm.wait()`
+  """
+
+
+def runProgramModule(filename: str, argv: _typing.List[str], extraPaths: _typing.List[str] = []) -> None:
+  """
+  Load and evaluate a program (main) module. Program modules must be written in JavaScript.
   """
 
 
@@ -117,6 +142,12 @@ class SpiderMonkeyError(Exception):
 
 
 null = _typing.Annotated[
-    _typing.NewType("pythonmonkey.null", object),
-    "Representing the JS null type in Python using a singleton object",
+  _typing.NewType("pythonmonkey.null", object),
+  "Representing the JS null type in Python using a singleton object",
+]
+
+
+globalThis = _typing.Annotated[
+  JSObjectProxy,
+  "A Python Dict which is equivalent to the globalThis object in JavaScript",
 ]

--- a/python/pythonmonkey/pythonmonkey.pyi
+++ b/python/pythonmonkey/pythonmonkey.pyi
@@ -115,10 +115,7 @@ class JSMethodProxy(JSFunctionProxy, object):
   print(myObject.value) # 42.0
   """
 
-  def __init__(self) -> None:
-    """
-    PythonMonkey init function
-    """
+  def __init__(self) -> None: "deleted"
 
 
 class JSObjectProxy(dict):
@@ -126,7 +123,31 @@ class JSObjectProxy(dict):
   JavaScript Object proxy dict
   """
 
-  def __init__(self) -> None: ...
+  def __init__(self) -> None: "deleted"
+
+
+class JSArrayProxy(list):
+  """
+  JavaScript Array proxy
+  """
+
+  def __init__(self) -> None: "deleted"
+
+
+class JSArrayIterProxy(_typing.Iterator):
+  """
+  JavaScript Array Iterator proxy
+  """
+
+  def __init__(self) -> None: "deleted"
+
+
+class JSStringProxy(str):
+  """
+  JavaScript String proxy
+  """
+
+  def __init__(self) -> None: "deleted"
 
 
 class bigint(int):

--- a/python/pythonmonkey/pythonmonkey.pyi
+++ b/python/pythonmonkey/pythonmonkey.pyi
@@ -1,4 +1,5 @@
 """
+stub file for type hints & documentations for the native module
 @see https://typing.readthedocs.io/en/latest/source/stubs.html
 """
 
@@ -55,6 +56,14 @@ def collect() -> None:
   """
 
 
+def internalBinding(namespace: str) -> JSObjectProxy:
+  """
+  INTERNAL USE ONLY
+
+  See function declarations in ./builtin_modules/internal-binding.d.ts
+  """
+
+
 class JSFunctionProxy():
   """
   JavaScript Function proxy
@@ -85,6 +94,26 @@ class JSMethodProxy(JSFunctionProxy, object):
     """
     PythonMonkey init function
     """
+
+
+class JSObjectProxy(dict):
+  """
+  JavaScript Object proxy dict
+  """
+
+  def __init__(self) -> None: ...
+
+
+class bigint(int):
+  """
+  Representing JavaScript BigInt in Python
+  """
+
+
+class SpiderMonkeyError(Exception):
+  """
+  Representing a corresponding JS Error in Python
+  """
 
 
 null = _typing.Annotated[


### PR DESCRIPTION
For https://github.com/Distributive-Network/PythonMonkey/pull/364/commits/f1f324162cf1ae3e7cf79d29964e2e9892524733, I have absolutely no idea why the type definitions were deleted by @philippedistributive in commit https://github.com/Distributive-Network/PythonMonkey/commit/d946421c2ef75e10f7c7f527f0d473bb087b3cde and https://github.com/Distributive-Network/PythonMonkey/commit/1f42778740b89e8f6947b13b2c6b4c80267f298c. 

`pm.bigint` is very useful when losslessly converting a Python `int` into JS and back (see https://github.com/Distributive-Network/PythonMonkey?tab=readme-ov-file#integer-type-coercion), thus must be included in the typings for the public API.