### PR TITLE
Fix the `Future exception not retrieved` issue

### DIFF
--- a/python/pythonmonkey/helpers.py
+++ b/python/pythonmonkey/helpers.py
@@ -43,8 +43,19 @@ function pmNewFactory(ctor)
   return (lambda *args: newCtor(list(args)))
 
 
+def simpleUncaughtExceptionHandler(loop, context):
+  """
+  A simple exception handler for uncaught JS Promise rejections sent to the Python event-loop
+
+  See https://docs.python.org/3.11/library/asyncio-eventloop.html#error-handling-api
+  """
+  error = context["exception"]
+  pm.eval("(err) => console.error('Uncaught', err)")(error)
+  pm.stop()  # unblock `await pm.wait()` to gracefully exit the program
+
+
 # List which symbols are exposed to the pythonmonkey module.
-__all__ = ["new", "typeof"]
+__all__ = ["new", "typeof", "simpleUncaughtExceptionHandler"]
 
 # Add the non-enumerable properties of globalThis which don't collide with pythonmonkey.so as exports:
 globalThis = pm.eval('globalThis')

--- a/src/JobQueue.cc
+++ b/src/JobQueue.cc
@@ -9,6 +9,7 @@
  */
 
 #include "include/JobQueue.hh"
+#include "include/modules/pythonmonkey/pythonmonkey.hh"
 
 #include "include/PyEventLoop.hh"
 #include "include/pyTypeFactory.hh"
@@ -139,10 +140,15 @@ void JobQueue::promiseRejectionTracker(JSContext *cx,
   if (!loop.initialized()) return;
   PyObject *customHandler = PyObject_GetAttrString(loop._loop, "_exception_handler"); // see https://github.com/python/cpython/blob/v3.9.16/Lib/asyncio/base_events.py#L1782
   if (customHandler == Py_None) { // we only have the default exception handler
-    return;
+    // Set an exception handler to the event-loop
+    PyObject *pmModule = PyImport_ImportModule("pythonmonkey");
+    PyObject *exceptionHandler = PyObject_GetAttrString(pmModule, "simpleUncaughtExceptionHandler");
+    PyObject_CallMethod(loop._loop, "set_exception_handler", "O", exceptionHandler);
+    Py_DECREF(pmModule);
+    Py_DECREF(exceptionHandler);
   }
 
-  // Otherwise, go ahead and send this unhandled Promise rejection to the exception handler on the Python event-loop
+  // Go ahead and send this unhandled Promise rejection to the exception handler on the Python event-loop
   PyObject *pyFuture = PromiseType::getPyObject(cx, promise); // ref count == 2
   // Unhandled Future object calls the event-loop exception handler in its destructor (the `__del__` magic method)
   // See https://github.com/python/cpython/blob/v3.9.16/Lib/asyncio/futures.py#L108

--- a/src/JobQueue.cc
+++ b/src/JobQueue.cc
@@ -147,7 +147,8 @@ void JobQueue::promiseRejectionTracker(JSContext *cx,
     Py_DECREF(pmModule);
     Py_DECREF(exceptionHandler);
   }
-Py_DECREF(customHandler);
+  Py_DECREF(customHandler);
+
   // Go ahead and send this unhandled Promise rejection to the exception handler on the Python event-loop
   PyObject *pyFuture = PromiseType::getPyObject(cx, promise); // ref count == 2
   // Unhandled Future object calls the event-loop exception handler in its destructor (the `__del__` magic method)

--- a/src/JobQueue.cc
+++ b/src/JobQueue.cc
@@ -147,7 +147,7 @@ void JobQueue::promiseRejectionTracker(JSContext *cx,
     Py_DECREF(pmModule);
     Py_DECREF(exceptionHandler);
   }
-
+Py_DECREF(customHandler);
   // Go ahead and send this unhandled Promise rejection to the exception handler on the Python event-loop
   PyObject *pyFuture = PromiseType::getPyObject(cx, promise); // ref count == 2
   // Unhandled Future object calls the event-loop exception handler in its destructor (the `__del__` magic method)

--- a/tests/js/uncaught-rejection-handler.bash
+++ b/tests/js/uncaught-rejection-handler.bash
@@ -1,0 +1,53 @@
+#! /bin/bash
+#
+# @file        uncaught-rejection-handler.bash
+#              For testing if the actual JS error gets printed out for uncaught Promise rejections, 
+#              instead of printing out a Python `Future exception was never retrieved` error message when not in pmjs
+#
+# @author      Tom Tang (xmader@distributive.network)
+# @date        June 2024
+
+set -u
+set -o pipefail
+
+panic()
+{
+  echo "FAIL: $*" >&2
+  exit 2
+}
+
+cd `dirname "$0"` || panic "could not change to test directory"
+
+code='
+import asyncio
+import pythonmonkey as pm
+
+async def pythonmonkey_main():
+  pm.eval("""void Promise.reject(new TypeError("abc"));""")
+  await pm.wait()
+
+asyncio.run(pythonmonkey_main())
+'
+
+OUTPUT=$(python -c "$code" \
+         < /dev/null 2>&1
+)
+
+echo "$OUTPUT" \
+| tr -d '\r' \
+| (grep -c 'Future exception was never retrieved' || true) \
+| while read qty
+  do
+    echo "$OUTPUT"
+    [ "$qty" != "0" ] && panic "There shouldn't be a 'Future exception was never retrieved' error massage"
+    break
+  done || exit $?
+
+echo "$OUTPUT" \
+| tr -d '\r' \
+| grep -c 'Uncaught TypeError: abc' \
+| while read qty
+  do
+    [ "$qty" != "1" ] && panic "It should print out 'Uncaught TypeError' directly"
+    break
+  done || exit $?


### PR DESCRIPTION
When not in the `pmjs` environment, uncaught JS Promise rejections would give a Python `Future exception was never retrieved` error message after https://github.com/Distributive-Network/PythonMonkey/pull/156 has been merged.

This PR would make it print out the actual JS error just like what it does in pmjs. 
![](https://github.com/Distributive-Network/PythonMonkey/assets/16057139/d535aab0-831b-470c-8363-ab9990a4a337)

![](https://github.com/Distributive-Network/PythonMonkey/assets/16057139/14236dd7-c9ab-4b21-a816-fc2999c6b46e)

---

closes https://github.com/Distributive-Network/PythonMonkey/issues/357