### PR TITLE
Chore(CI): fix building `uncrustify` on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ _spidermonkey_install
 uncrustify-*.tar.gz
 uncrustify-*/
 uncrustify
+uncrustify.exe
 *.uncrustify
 __pycache__/*
 dist

--- a/setup.sh
+++ b/setup.sh
@@ -58,9 +58,15 @@ echo "Building uncrustify"
 cd uncrustify-source
 mkdir -p build
 cd build
-cmake ../
-make -j4
-cp uncrustify ../../uncrustify
+if [[ "$OSTYPE" == "msys"* ]]; then # Windows
+  cmake ../ -T ClangCL
+  cmake --build . -j$CPUS --config Release
+  cp Release/uncrustify.exe ../../uncrustify.exe
+else
+  cmake ../
+  make -j$CPUS
+  cp uncrustify ../../uncrustify
+fi
 cd ../..
 echo "Done building uncrustify"
 


### PR DESCRIPTION
https://github.com/Distributive-Network/PythonMonkey/actions/runs/9576344507/job/26402698600#step:6:5197

SpiderMonkey build fails on Windows when building uncrustify (on `main` branch)
```console
make: *** No targets specified and no makefile found.  Stop.
```

---

It seems to be a long existing issue, probably since https://github.com/Distributive-Network/PythonMonkey/pull/322 changed how `uncrustify` is built.
However, we haven't run any full SpiderMonkey build (we're always using the build cache) in the past 2 months since the PR was merged, so the issue hasn't been surfaced until recently... :sweat_smile: 