### PR TITLE
Properly print/repr Promises/Futures and structural cycles at the JS level

### DIFF
--- a/src/JSArrayProxy.cc
+++ b/src/JSArrayProxy.cc
@@ -511,15 +511,24 @@ PyObject *JSArrayProxyMethodDefinitions::JSArrayProxy_richcompare(JSArrayProxy *
 }
 
 PyObject *JSArrayProxyMethodDefinitions::JSArrayProxy_repr(JSArrayProxy *self) {
+  // Detect cyclic objects
+  PyObject *objPtr = PyLong_FromVoidPtr(self->jsArray->get());
+  // For `Py_ReprEnter`, we must get a same PyObject when visiting the same JSObject.
+  // We cannot simply use the object returned by `PyLong_FromVoidPtr` because it won't reuse the PyLongObjects for ints not between -5 and 256.
+  // Instead, we store this PyLongObject in a global dict, using itself as the hashable key, effectively interning the PyLongObject.
+  PyObject *tsDict = PyThreadState_GetDict();
+  PyObject *cyclicKey = PyDict_SetDefault(tsDict, /*key*/ objPtr, /*value*/ objPtr); // cyclicKey = (tsDict[objPtr] ??= objPtr)
+  int i = Py_ReprEnter(cyclicKey);
+  if (i != 0) {
+    return i > 0 ? PyUnicode_FromString("[...]") : NULL;
+  }
+
   Py_ssize_t selfLength = JSArrayProxy_length(self);
 
   if (selfLength == 0) {
+    Py_ReprLeave(cyclicKey);
+    PyDict_DelItem(tsDict, cyclicKey);
     return PyUnicode_FromString("[]");
-  }
-
-  Py_ssize_t i = Py_ReprEnter((PyObject *)self);
-  if (i != 0) {
-    return i > 0 ? PyUnicode_FromString("[...]") : NULL;
   }
 
   _PyUnicodeWriter writer;
@@ -569,12 +578,14 @@ PyObject *JSArrayProxyMethodDefinitions::JSArrayProxy_repr(JSArrayProxy *self) {
     goto error;
   }
 
-  Py_ReprLeave((PyObject *)self);
+  Py_ReprLeave(cyclicKey);
+  PyDict_DelItem(tsDict, cyclicKey);
   return _PyUnicodeWriter_Finish(&writer);
 
 error:
   _PyUnicodeWriter_Dealloc(&writer);
-  Py_ReprLeave((PyObject *)self);
+  Py_ReprLeave(cyclicKey);
+  PyDict_DelItem(tsDict, cyclicKey);
   return NULL;
 }
 

--- a/src/JSObjectProxy.cc
+++ b/src/JSObjectProxy.cc
@@ -338,7 +338,14 @@ PyObject *JSObjectProxyMethodDefinitions::JSObjectProxy_iter_next(JSObjectProxy 
 }
 
 PyObject *JSObjectProxyMethodDefinitions::JSObjectProxy_repr(JSObjectProxy *self) {
-  Py_ssize_t i = Py_ReprEnter((PyObject *)self);
+  // Detect cyclic objects
+  PyObject *objPtr = PyLong_FromVoidPtr(self->jsObject->get());
+  // For `Py_ReprEnter`, we must get a same PyObject when visiting the same JSObject.
+  // We cannot simply use the object returned by `PyLong_FromVoidPtr` because it won't reuse the PyLongObjects for ints not between -5 and 256.
+  // Instead, we store this PyLongObject in a global dict, using itself as the hashable key, effectively interning the PyLongObject.
+  PyObject *tsDict = PyThreadState_GetDict();
+  PyObject *cyclicKey = PyDict_SetDefault(tsDict, /*key*/ objPtr, /*value*/ objPtr); // cyclicKey = (tsDict[objPtr] ??= objPtr)
+  int i = Py_ReprEnter(cyclicKey);
   if (i != 0) {
     return i > 0 ? PyUnicode_FromString("{...}") : NULL;
   }
@@ -346,7 +353,8 @@ PyObject *JSObjectProxyMethodDefinitions::JSObjectProxy_repr(JSObjectProxy *self
   Py_ssize_t selfLength = JSObjectProxy_length(self);
 
   if (selfLength == 0) {
-    Py_ReprLeave((PyObject *)self);
+    Py_ReprLeave(cyclicKey);
+    PyDict_DelItem(tsDict, cyclicKey);
     return PyUnicode_FromString("{}");
   }
 
@@ -417,15 +425,24 @@ PyObject *JSObjectProxyMethodDefinitions::JSObjectProxy_repr(JSObjectProxy *self
       value = pyTypeFactory(GLOBAL_CX, elementVal);
     }
 
-    s = PyObject_Repr(value);
-    if (s == NULL) {
-      goto error;
-    }
+    if (value != NULL) {
+      s = PyObject_Repr(value);
+      if (s == NULL) {
+        goto error;
+      }
 
-    res = _PyUnicodeWriter_WriteStr(&writer, s);
-    Py_DECREF(s);
-    if (res < 0) {
-      goto error;
+      res = _PyUnicodeWriter_WriteStr(&writer, s);
+      Py_DECREF(s);
+      if (res < 0) {
+        goto error;
+      }
+    } else {
+      // clear exception that was just set
+      PyErr_Clear();
+
+      if (_PyUnicodeWriter_WriteASCIIString(&writer, "<cannot repr type>", 19)  < 0) {
+        goto error;
+      }
     }
 
     Py_CLEAR(key);
@@ -437,11 +454,13 @@ PyObject *JSObjectProxyMethodDefinitions::JSObjectProxy_repr(JSObjectProxy *self
     goto error;
   }
 
-  Py_ReprLeave((PyObject *)self);
+  Py_ReprLeave(cyclicKey);
+  PyDict_DelItem(tsDict, cyclicKey);
   return _PyUnicodeWriter_Finish(&writer);
 
 error:
-  Py_ReprLeave((PyObject *)self);
+  Py_ReprLeave(cyclicKey);
+  PyDict_DelItem(tsDict, cyclicKey);
   _PyUnicodeWriter_Dealloc(&writer);
   Py_XDECREF(key);
   Py_XDECREF(value);

--- a/src/JSObjectProxy.cc
+++ b/src/JSObjectProxy.cc
@@ -437,7 +437,7 @@ PyObject *JSObjectProxyMethodDefinitions::JSObjectProxy_repr(JSObjectProxy *self
         goto error;
       }
     } else {
-      // clear exception that was just set
+      // clear any exception that was just set
       PyErr_Clear();
 
       if (_PyUnicodeWriter_WriteASCIIString(&writer, "<cannot repr type>", 19)  < 0) {


### PR DESCRIPTION
Handle NULL result from pyTypeFactory and clear any exception
Take into account the proxy's jsObject address for detecting cycles

closes https://github.com/Distributive-Network/PythonMonkey/issues/379