### PR TITLE
Support console printing of iterable proxy

### DIFF
--- a/src/PyIterableProxyHandler.cc
+++ b/src/PyIterableProxyHandler.cc
@@ -66,8 +66,48 @@ static bool iterable_next(JSContext *cx, unsigned argc, JS::Value *vp) {
   return iter_next(cx, args, it);
 }
 
+static bool toPrimitive(JSContext *cx, unsigned argc, JS::Value *vp) {
+  JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
+
+  JS::RootedObject proxy(cx, JS::ToObject(cx, args.thisv()));
+  if (!proxy) {
+    return false;
+  }
+
+  PyObject *self = JS::GetMaybePtrFromReservedSlot<PyObject>(proxy, PyObjectSlot);
+
+  _PyUnicodeWriter writer;
+
+  _PyUnicodeWriter_Init(&writer);
+  
+  PyObject *s = PyObject_Repr(self);
+
+  if (s == nullptr) {
+    args.rval().setString(JS_NewStringCopyZ(cx, "<cannot repr type>"));
+    return true;
+  }
+
+  int res = _PyUnicodeWriter_WriteStr(&writer, s);
+  Py_DECREF(s);
+
+  if (res < 0) {
+    args.rval().setString(JS_NewStringCopyZ(cx, "<cannot repr type>"));
+    return true;
+  }
+
+  PyObject* repr = _PyUnicodeWriter_Finish(&writer);
+ 
+  args.rval().set(jsTypeFactory(cx, repr));
+  return true;
+}
+
+static bool iterable_valueOf(JSContext *cx, unsigned argc, JS::Value *vp) {
+  return toPrimitive(cx, argc, vp);
+}
+
 JSMethodDef PyIterableProxyHandler::iterable_methods[] = {
   {"next", iterable_next, 0},
+  {"valueOf", iterable_valueOf, 0},
   {NULL, NULL, 0}
 };
 
@@ -172,7 +212,7 @@ bool PyIterableProxyHandler::getOwnPropertyDescriptor(
   JSContext *cx, JS::HandleObject proxy, JS::HandleId id,
   JS::MutableHandle<mozilla::Maybe<JS::PropertyDescriptor>> desc
 ) const {
-
+  
   // see if we're calling a function
   if (id.isString()) {
     for (size_t index = 0;; index++) {
@@ -196,12 +236,52 @@ bool PyIterableProxyHandler::getOwnPropertyDescriptor(
     }
   }
 
+  // "constructor" property
+  bool isConstructorProperty;
+  if (id.isString() && JS_StringEqualsLiteral(cx, id.toString(), "constructor", &isConstructorProperty) && isConstructorProperty) {
+    //printf("PyIterableProxyHandler::handleGetOwnPropertyDescriptor constructor\n");
+    JS::RootedObject global(cx, JS::GetNonCCWObjectGlobal(proxy));
+
+    JS::RootedObject rootedObjectPrototype(cx);
+    if (!JS_GetClassPrototype(cx, JSProto_Object, &rootedObjectPrototype)) {
+      return false;
+    }
+
+    JS::RootedValue Object_Prototype_Constructor(cx);
+    if (!JS_GetProperty(cx, rootedObjectPrototype, "constructor", &Object_Prototype_Constructor)) {
+      return false;
+    }
+
+    JS::RootedObject rootedObjectPrototypeConstructor(cx, Object_Prototype_Constructor.toObjectOrNull());
+
+    desc.set(mozilla::Some(
+      JS::PropertyDescriptor::Data(
+        JS::ObjectValue(*rootedObjectPrototypeConstructor),
+        {JS::PropertyAttribute::Enumerable}
+      )
+    ));
+    return true;
+  }
+
   // symbol property
   if (id.isSymbol()) {
     JS::RootedSymbol rootedSymbol(cx, id.toSymbol());
+    JS::SymbolCode symbolCode = JS::GetSymbolCode(rootedSymbol); 
 
-    if (JS::GetSymbolCode(rootedSymbol) == JS::SymbolCode::iterator) {
+    if (symbolCode == JS::SymbolCode::iterator) {
       JSFunction *newFunction = JS_NewFunction(cx, iterable_values, 0, 0, NULL);
+      if (!newFunction) return false;
+      JS::RootedObject funObj(cx, JS_GetFunctionObject(newFunction));
+      desc.set(mozilla::Some(
+        JS::PropertyDescriptor::Data(
+          JS::ObjectValue(*funObj),
+          {JS::PropertyAttribute::Enumerable}
+        )
+      ));
+      return true;
+    } 
+    else if (symbolCode == JS::SymbolCode::toPrimitive) {
+      JSFunction *newFunction = JS_NewFunction(cx, toPrimitive, 0, 0, nullptr);
       if (!newFunction) return false;
       JS::RootedObject funObj(cx, JS_GetFunctionObject(newFunction));
       desc.set(mozilla::Some(

--- a/src/PyIterableProxyHandler.cc
+++ b/src/PyIterableProxyHandler.cc
@@ -212,7 +212,6 @@ bool PyIterableProxyHandler::getOwnPropertyDescriptor(
   JSContext *cx, JS::HandleObject proxy, JS::HandleId id,
   JS::MutableHandle<mozilla::Maybe<JS::PropertyDescriptor>> desc
 ) const {
-  
   // see if we're calling a function
   if (id.isString()) {
     for (size_t index = 0;; index++) {
@@ -239,7 +238,6 @@ bool PyIterableProxyHandler::getOwnPropertyDescriptor(
   // "constructor" property
   bool isConstructorProperty;
   if (id.isString() && JS_StringEqualsLiteral(cx, id.toString(), "constructor", &isConstructorProperty) && isConstructorProperty) {
-    //printf("PyIterableProxyHandler::handleGetOwnPropertyDescriptor constructor\n");
     JS::RootedObject global(cx, JS::GetNonCCWObjectGlobal(proxy));
 
     JS::RootedObject rootedObjectPrototype(cx);

--- a/tests/python/test_objects.py
+++ b/tests/python/test_objects.py
@@ -1,4 +1,5 @@
 import pythonmonkey as pm
+import sys
 
 
 def test_eval_pyobjects():
@@ -158,5 +159,15 @@ def test_toPrimitive_iterable():
 
 def test_constructor_iterable():
   iterable = iter([1,2])
-  toPrimitive = pm.eval("(obj) => { return obj.constructor; }")(iterable)
-  assert repr(toPrimitive).__contains__("<pythonmonkey.JSFunctionProxy object at")    
+  constructor = pm.eval("(obj) => { return obj.constructor; }")(iterable)
+  assert repr(constructor).__contains__("<pythonmonkey.JSFunctionProxy object at")    
+
+
+def test_toPrimitive_stdin():
+  toPrimitive = pm.eval("(obj) => { return obj[Symbol.toPrimitive]; }")(sys.stdin)
+  assert repr(toPrimitive).__contains__("<pythonmonkey.JSFunctionProxy object at")  
+
+
+def test_constructor_stdin():
+  constructor = pm.eval("(obj) => { return obj.constructor; }")(sys.stdin)
+  assert repr(constructor).__contains__("<pythonmonkey.JSFunctionProxy object at")      

--- a/tests/python/test_objects.py
+++ b/tests/python/test_objects.py
@@ -148,3 +148,15 @@ def test_pyobjects_toLocaleString():
 
   o = MyClass()
   assert '[object Object]' == pm.eval("(obj) => { return obj.toLocaleString(); }")(o)
+
+
+def test_toPrimitive_iterable():
+  iterable = iter([1,2])
+  toPrimitive = pm.eval("(obj) => { return obj[Symbol.toPrimitive]; }")(iterable)
+  assert repr(toPrimitive).__contains__("<pythonmonkey.JSFunctionProxy object at")  
+
+
+def test_constructor_iterable():
+  iterable = iter([1,2])
+  toPrimitive = pm.eval("(obj) => { return obj.constructor; }")(iterable)
+  assert repr(toPrimitive).__contains__("<pythonmonkey.JSFunctionProxy object at")    


### PR DESCRIPTION
Added constructor and Symbol.toPrimitive properties to Iterable proxy as required by console.log

closes https://github.com/Distributive-Network/PythonMonkey/issues/390
closes https://github.com/Distributive-Network/PythonMonkey/issues/388