### PR TITLE
PyObject is not necessarily a dict in Iterable proxy when getting an attribute

### DIFF
--- a/src/PyIterableProxyHandler.cc
+++ b/src/PyIterableProxyHandler.cc
@@ -294,7 +294,7 @@ bool PyIterableProxyHandler::getOwnPropertyDescriptor(
 
   PyObject *attrName = idToKey(cx, id);
   PyObject *self = JS::GetMaybePtrFromReservedSlot<PyObject>(proxy, PyObjectSlot);
-  PyObject *item = PyDict_GetItemWithError(self, attrName);
+  PyObject *item = PyObject_GetAttr(self, attrName);
 
   return handleGetOwnPropertyDescriptor(cx, id, desc, item);
 }

--- a/tests/python/test_objects.py
+++ b/tests/python/test_objects.py
@@ -174,7 +174,7 @@ def test_constructor_stdin():
   assert repr(constructor).__contains__("<pythonmonkey.JSFunctionProxy object at")      
 
 
-def test_iterable_member_console_printing():
+def test_iterable_attribute_console_printing():
   temp_out = StringIO()
   sys.stdout = temp_out
   obj = {}

--- a/tests/python/test_objects.py
+++ b/tests/python/test_objects.py
@@ -174,11 +174,12 @@ def test_constructor_stdin():
   assert repr(constructor).__contains__("<pythonmonkey.JSFunctionProxy object at")      
 
 
-def test_stdin_tty_console_printing():
+def test_iterable_member_console_printing():
   temp_out = StringIO()
   sys.stdout = temp_out
   obj = {}
-  obj['stdin'] = sys.stdin
+  obj['stdin'] = sys.stdin   # sys.stdin is iterable
+  assert hasattr(sys.stdin, '__iter__') == True
   obj['stdin'].isTTY = sys.stdin.isatty()
   pm.eval('''(function iife(obj){console.log(obj['stdin'].isTTY);})''')(obj)
   assert temp_out.getvalue() == "\x1b[33mfalse\x1b[39m\n"

--- a/tests/python/test_objects.py
+++ b/tests/python/test_objects.py
@@ -1,6 +1,5 @@
 import pythonmonkey as pm
 import sys
-from io import StringIO
 
 
 def test_eval_pyobjects():
@@ -172,14 +171,3 @@ def test_toPrimitive_stdin():
 def test_constructor_stdin():
   constructor = pm.eval("(obj) => { return obj.constructor; }")(sys.stdin)
   assert repr(constructor).__contains__("<pythonmonkey.JSFunctionProxy object at")      
-
-
-def test_iterable_attribute_console_printing():
-  temp_out = StringIO()
-  sys.stdout = temp_out
-  obj = {}
-  obj['stdin'] = sys.stdin   # sys.stdin is iterable
-  assert hasattr(sys.stdin, '__iter__') == True
-  obj['stdin'].isTTY = sys.stdin.isatty()
-  pm.eval('''(function iife(obj){console.log(obj['stdin'].isTTY);})''')(obj)
-  assert temp_out.getvalue() == "\x1b[33mfalse\x1b[39m\n"

--- a/tests/python/test_objects.py
+++ b/tests/python/test_objects.py
@@ -1,5 +1,6 @@
 import pythonmonkey as pm
 import sys
+from io import StringIO
 
 
 def test_eval_pyobjects():
@@ -171,3 +172,13 @@ def test_toPrimitive_stdin():
 def test_constructor_stdin():
   constructor = pm.eval("(obj) => { return obj.constructor; }")(sys.stdin)
   assert repr(constructor).__contains__("<pythonmonkey.JSFunctionProxy object at")      
+
+
+def test_stdin_tty_console_printing():
+  temp_out = StringIO()
+  sys.stdout = temp_out
+  obj = {}
+  obj['stdin'] = sys.stdin
+  obj['stdin'].isTTY = sys.stdin.isatty()
+  pm.eval('''(function iife(obj){console.log(obj['stdin'].isTTY);})''')(obj)
+  assert temp_out.getvalue() == "\x1b[33mfalse\x1b[39m\n"

--- a/tests/python/test_pythonmonkey_eval.py
+++ b/tests/python/test_pythonmonkey_eval.py
@@ -440,3 +440,14 @@ def test_console_array():
   items = [1, 2, 3]
   pm.eval('console.log')(items)
   assert temp_out.getvalue() == "[ \x1b[33m1\x1b[39m, \x1b[33m2\x1b[39m, \x1b[33m3\x1b[39m ]\n"
+
+
+def test_iterable_attribute_console_printing():
+  temp_out = StringIO()
+  sys.stdout = temp_out
+  obj = {}
+  obj['stdin'] = sys.stdin   # sys.stdin is iterable
+  assert hasattr(sys.stdin, '__iter__') == True
+  obj['stdin'].isTTY = sys.stdin.isatty()
+  pm.eval('''(function iife(obj){console.log(obj['stdin'].isTTY);})''')(obj)
+  assert temp_out.getvalue() == "\x1b[33mfalse\x1b[39m\n" 


### PR DESCRIPTION
Call PyObject_GetAttr instead of PyDict_GetItemWithError in iterable proxy

closes https://github.com/Distributive-Network/PythonMonkey/issues/389