### PR TITLE
check for SystemExit before scheduling timer

### DIFF
--- a/src/internalBinding/timers.cc
+++ b/src/internalBinding/timers.cc
@@ -23,6 +23,11 @@ using AsyncHandle = PyEventLoop::AsyncHandle;
  */
 
 static bool enqueueWithDelay(JSContext *cx, unsigned argc, JS::Value *vp) {
+  if (PyErr_Occurred() && PyErr_ExceptionMatches(PyExc_SystemExit)) {
+     // quit, exit or sys.exit was called (and raised SystemExit)
+     return false;
+  }
+
   JS::CallArgs args = JS::CallArgsFromVp(argc, vp);
   JS::HandleValue jobArgVal = args.get(0);
   double delaySeconds = args.get(1).toNumber();


### PR DESCRIPTION
Prevent inconsistent state crashing by exiting next operation called from JS early when system exit is under way

closes https://github.com/Distributive-Network/PythonMonkey/issues/387