### PR TITLE
fix: base64.py 'Incorrect padding' error

### DIFF
--- a/python/pythonmonkey/builtin_modules/base64.py
+++ b/python/pythonmonkey/builtin_modules/base64.py
@@ -8,10 +8,8 @@ import base64
 
 
 def atob(b64):
-  # Workaround for pythons 'Incorrect padding' error when base64 decoding, see: 
-  # https://stackoverflow.com/questions/2941995/python-ignore-incorrect-padding-error-when-base64-decoding
-  append = b"==" if isinstance(b64, bytes) else "=="
-  return str(base64.standard_b64decode(b64 + append), 'latin1')
+  padding = '=' * (4 - (len(b64) & 3))
+  return str(base64.standard_b64decode(b64 + padding), 'latin1')
 
 
 def btoa(data):

--- a/python/pythonmonkey/builtin_modules/base64.py
+++ b/python/pythonmonkey/builtin_modules/base64.py
@@ -8,7 +8,10 @@ import base64
 
 
 def atob(b64):
-  return str(base64.standard_b64decode(b64), 'latin1')
+  # Workaround for pythons 'Incorrect padding' error when base64 decoding, see: 
+  # https://stackoverflow.com/questions/2941995/python-ignore-incorrect-padding-error-when-base64-decoding
+  append = b"==" if isinstance(b64, bytes) else "=="
+  return str(base64.standard_b64decode(b64 + append), 'latin1')
 
 
 def btoa(data):


### PR DESCRIPTION
# Fix:
Update python implementation of 'atob' to properly reflect behaviour of JS 'atob' by padding the base64 with "==".
https://stackoverflow.com/questions/2941995/python-ignore-incorrect-padding-error-when-base64-decoding

# Motivation:
This fixes a number of JavaScript implementations for different Cryptography logic which takes advantage of `atob`s behavior, much of this logic doesn't take into account the padding, however Python's base64 library does.
Since padding is arbitrary we can append "==" to the string before decoding.
`aGVsbG8gd29ybGQ` -> raises `binascii.Error`
`aGVsbG8gd29ybGQ=` -> `hello world`
`aGVsbG8gd29ybGQ==` -> `hello world`
`aGVsbG8gd29ybGQ===` -> `hello world`
and so on...

# Examples:

## Python - decode "hello world" no padding
```py 
import base64
data = "aGVsbG8gd29ybGQ"
base64.standard_b64decode(data)
```
`binascii.Error: Incorrect padding`


## JavaScript - decode "hello world" no padding
```js
atob("aGVsbG8gd29ybGQ")
```
`'hello world'`

## Python - decode "hello world" with padding
```py
import base64
data = "aGVsbG8gd29ybGQ"
base64.standard_b64decode(data + "==")
```
`b'hello world'`