### PR TITLE
Fix Windows build for finding the `cargo` executable

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -34,15 +34,15 @@ fi
 # Install rust compiler
 echo "Installing rust compiler"
 curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.76
-. $HOME/.cargo/env
-cargo install cbindgen
+CARGO_BIN="$HOME/.cargo/bin/cargo" # also works for Windows. On Windows this equals to %USERPROFILE%\.cargo\bin\cargo
+$CARGO_BIN install cbindgen
 # Setup Poetry
 echo "Installing poetry"
 curl -sSL https://install.python-poetry.org | python3 - --version "1.7.1"
 if [[ "$OSTYPE" == "msys"* ]]; then # Windows
   POETRY_BIN="$APPDATA/Python/Scripts/poetry"
 else
-  POETRY_BIN=`echo ~/.local/bin/poetry` # expand tilde
+  POETRY_BIN="$HOME/.local/bin/poetry"
 fi
 $POETRY_BIN self add 'poetry-dynamic-versioning[plugin]'
 echo "Done installing dependencies"


### PR DESCRIPTION
PR https://github.com/Distributive-Network/PythonMonkey/pull/386 tried to make the `cargo` executable immediately available in the current shell by sourcing `$HOME/.cargo/env`.

> console messages when cargo is installed by `rustup` on *nix
```console
Rust is installed now. Great!

To get started you may need to restart your current shell.
This would reload your PATH environment variable to include
Cargo's bin directory ($HOME/.cargo/bin).

To configure your current shell, you need to source
the corresponding env file under $HOME/.cargo.

This is usually done by running one of the following (note the leading DOT):
. "$HOME/.cargo/env"            # For sh/bash/zsh/ash/dash/pdksh
source "$HOME/.cargo/env.fish"  # For fish
```

However, this method does not work in Windows, and thus breaks our Windows build CI.

> console messages when cargo is installed by `rustup` on Windows
```console
Rust is installed now. Great!
To get started you may need to restart your current shell.
This would reload its PATH environment variable to include
Cargo's bin directory (%USERPROFILE%\.cargo\bin).
```

[Error](https://github.com/Distributive-Network/PythonMonkey/actions/runs/10405813349/job/28817439334#step:7:51)

```
 ./setup.sh: line 37: /c/Users/runneradmin/.cargo/env: No such file or directory
```

---

This PR fixes this error by executing `cargo` by its absolute path.

---

Closes https://github.com/Distributive-Network/PythonMonkey/issues/408