### PR TITLE
chore(CI): remove CI runs on Ubuntu 24.04

### DIFF
--- a/.github/workflows/test-and-publish.yaml
+++ b/.github/workflows/test-and-publish.yaml
@@ -59,9 +59,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Use Ubuntu 20.04 / Ubuntu 24.04 / macOS 13 x86_64 / macOS 14 arm64 + Python 3.10 to build SpiderMonkey
-        os: [ 'ubuntu-20.04', 'ubuntu-24.04', 'macos-13', 'macos-14', 'pi' ] # macOS 14 runner exclusively runs on M1 hardwares
-                                                       # see https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available
+        # Use Ubuntu 20.04 / macOS 13 x86_64 / macOS 14 arm64 + Python 3.10 to build SpiderMonkey
+        os: [ 'ubuntu-20.04', 'macos-13', 'macos-14', 'pi' ] # macOS 14 runner exclusively runs on M1 hardwares
+                                                             # see https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available
         python_version: [ '3.10' ]
     runs-on: ${{ matrix.os }}
     steps:
@@ -127,7 +127,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ 'ubuntu-20.04', 'ubuntu-24.04', 'macos-12', 'macos-14', 'windows-2022', 'pi' ]
+        os: [ 'ubuntu-20.04', 'macos-12', 'macos-14', 'windows-2022', 'pi' ]
         python_version: [ '3.8', '3.9', '3.10', '3.11', '3.12' ]
         exclude:
           # actions/setup-python: The version '3.8'/'3.9' with architecture 'arm64' was not found for macOS.


### PR DESCRIPTION
Binaries built on Ubuntu 20.04 (uses glibc version 2.31) can run on Ubuntu 24.04 (glibc version 2.38) without any problem, but not the other way around.
We should only build on the lowest OS version possible.


CI on Ubuntu 20.04 [sometimes](https://github.com/Distributive-Network/PythonMonkey/actions/runs/10457908558/job/28963201132#step:15:154) [fails](https://github.com/Distributive-Network/PythonMonkey/actions/runs/10457594637/job/28957705334#step:15:754) because it somehow tries to pick up the binaries built for Ubuntu 24.04 (needs glibc version 2.38), which is incompatible with Ubuntu 20.04 (only has glibc version 2.31).

---

The issue https://github.com/Distributive-Network/PythonMonkey/issues/356 reported for having trouble on Ubuntu 24.04 has nothing to do with building/compiling on 24.04. 
It's actually about the problem of installing from **sdist** on Ubuntu 24.04 due to a dependency.
Since we already have the [check-install-from-sdist](https://github.com/Distributive-Network/PythonMonkey/blob/99a9f27/.github/workflows/test-and-publish.yaml#L280-L292) step running on 24.04, the tests should cover that problem.