### PR TITLE
CI: add Python 3.8 & 3.9 builds on arm64 macOS

### DIFF
--- a/.github/workflows/test-and-publish.yaml
+++ b/.github/workflows/test-and-publish.yaml
@@ -129,13 +129,6 @@ jobs:
       matrix:
         os: [ 'ubuntu-20.04', 'macos-12', 'macos-14', 'windows-2022', 'pi' ]
         python_version: [ '3.8', '3.9', '3.10', '3.11', '3.12' ]
-        exclude:
-          # actions/setup-python: The version '3.8'/'3.9' with architecture 'arm64' was not found for macOS.
-          # see https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
-          - os: 'macos-14'
-            python_version: '3.8'
-          - os: 'macos-14'
-            python_version: '3.9'
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
`actions/setup-python` now added prebuilt Python 3.8 & 3.9 packages for arm64 macOS.

See https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
```json
{
    "version": "3.8.10",
    "stable": true,
    "release_url": "https://github.com/actions/python-versions/releases/tag/3.8.10-8879978422",
    "files": [
      {
        "filename": "python-3.8.10-darwin-arm64.tar.gz",
        "arch": "arm64",
        "platform": "darwin",
        "download_url": "https://github.com/actions/python-versions/releases/download/3.8.10-8879978422/python-3.8.10-darwin-arm64.tar.gz"
      },
      ...
```

```json
{
    "version": "3.9.13",
    "stable": true,
    "release_url": "https://github.com/actions/python-versions/releases/tag/3.9.13-8879985561",
    "files": [
      {
        "filename": "python-3.9.13-darwin-arm64.tar.gz",
        "arch": "arm64",
        "platform": "darwin",
        "download_url": "https://github.com/actions/python-versions/releases/download/3.9.13-8879985561/python-3.9.13-darwin-arm64.tar.gz"
      },
      ...
```

Previously there were unavailable.
```console
The version '3.8' with architecture 'arm64' was not found for macOS.
```