### PR TITLE
Small changes on the `mozilla-central` updater CI

### DIFF
--- a/.github/workflows/update-mozcentral-version.yaml
+++ b/.github/workflows/update-mozcentral-version.yaml
@@ -40,3 +40,4 @@ jobs:
           body: |
             Changeset: https://hg.mozilla.org/mozilla-central/rev/${{ env.MOZCENTRAL_VERSION }}
           labels: dependencies
+          assignees: Xmader

--- a/.github/workflows/update-mozcentral-version.yaml
+++ b/.github/workflows/update-mozcentral-version.yaml
@@ -33,6 +33,7 @@ jobs:
           add-paths: mozcentral.version
           commit-message: |
             chore(deps): upgrade SpiderMonkey to `${{ env.MOZCENTRAL_VERSION }}`
+          author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           branch: chore/upgrade-spidermonkey-to-${{ env.MOZCENTRAL_VERSION_SHORT }}
           title: Upgrade SpiderMonkey to mozilla-central commit `${{ env.MOZCENTRAL_VERSION }}`
           body: |

--- a/.github/workflows/update-mozcentral-version.yaml
+++ b/.github/workflows/update-mozcentral-version.yaml
@@ -2,7 +2,8 @@ name: 'Create pull requests to update mozilla-central version to the latest'
 
 on:
   schedule:
-    - cron: "00 14 * * 1" # run every Monday at 14:00 UTC (10:00 Eastern Daylight Time)
+    - cron: "00 14 */100,1-7 * 1" # run on the first Monday of each month at 14:00 UTC (10:00 Eastern Daylight Time)
+                                  # See https://blog.healthchecks.io/2022/09/schedule-cron-job-the-funky-way/
   workflow_call:
   workflow_dispatch: # or you can run it manually
 


### PR DESCRIPTION
Small changes on the `mozilla-central` updater CI that was introduced in https://github.com/Distributive-Network/PythonMonkey/pull/367 https://github.com/Distributive-Network/PythonMonkey/commit/a7b92e896ff6b077f161b9ae79a9f5e55f4434b5

* Fix the problem where the CI commit [always says](https://github.com/Distributive-Network/PythonMonkey/pull/416/commits/914ec9be46467069f8fdf9443b56fe6964b4aa0b) @philippedistributive to be the author 
* Automatically assign @Xmader to the PRs
* Lower the update frequency since we don't have enough bandwidth