### PR TITLE
set max gc heap size to maximum available

### DIFF
--- a/src/modules/pythonmonkey/pythonmonkey.cc
+++ b/src/modules/pythonmonkey/pythonmonkey.cc
@@ -562,6 +562,8 @@ PyMODINIT_FUNC PyInit_pythonmonkey(void)
     return NULL;
   }
 
+  JS_SetGCParameter(GLOBAL_CX, JSGC_MAX_BYTES, (uint32_t)-1);
+
   JS_SetGCCallback(GLOBAL_CX, pythonmonkeyGCCallback, NULL);
 
   JS::RealmCreationOptions creationOptions = JS::RealmCreationOptions();


### PR DESCRIPTION
Set GC max heap size to maximum available to avoid OOM errors

This is done routinely in Spidermonkey (see for example https://searchfox.org/mozilla-central/rev/e968519d806b140c402c3b3932cd5f6cd7cc42ac/js/src/shell/js.cpp#13452)

See also https://discourse.mozilla.org/t/how-does-spidermonkey-deal-with-memory-limitations/123670/2