### PR TITLE
Fix the string corruption bug

### DIFF
--- a/src/PyObjectProxyHandler.cc
+++ b/src/PyObjectProxyHandler.cc
@@ -44,8 +44,9 @@ bool PyObjectProxyHandler::handleGetOwnPropertyDescriptor(JSContext *cx, JS::Han
   JS::MutableHandle<mozilla::Maybe<JS::PropertyDescriptor>> desc, PyObject *item) {
   // see if we're calling a function
   if (id.isString()) {
-    JS::RootedString idString(cx, id.toString());
-    const char *methodName = JS_EncodeStringToUTF8(cx, idString).get();
+    JS::UniqueChars idString = JS_EncodeStringToUTF8(cx, JS::RootedString(cx, id.toString()));
+    const char *methodName = idString.get();
+
     if (!strcmp(methodName, "toString") || !strcmp(methodName, "toLocaleString") || !strcmp(methodName, "valueOf")) {
       JS::RootedObject objectPrototype(cx);
       if (!JS_GetClassPrototype(cx, JSProto_Object, &objectPrototype)) {

--- a/src/modules/pythonmonkey/pythonmonkey.cc
+++ b/src/modules/pythonmonkey/pythonmonkey.cc
@@ -48,25 +48,39 @@
 
 JS::PersistentRootedObject jsFunctionRegistry;
 
+/**
+ * @brief During a GC, string buffers may have moved, so we need to re-point our JSStringProxies
+ * The char buffer pointer obtained by previous `JS::Get{Latin1,TwoByte}LinearStringChars` calls remains valid only as long as no GC occurs.
+ */
+void updateCharBufferPointers() {
+  if (_Py_IsFinalizing()) {
+    return; // do not move char pointers around if python is finalizing
+  }
+
+  JS::AutoCheckCannotGC nogc;
+  for (const JSStringProxy *jsStringProxy: jsStringProxies) {
+    JSLinearString *str = JS_ASSERT_STRING_IS_LINEAR(jsStringProxy->jsString->toString());
+    void *updatedCharBufPtr; // pointer to the moved char buffer after a GC
+    if (JS::LinearStringHasLatin1Chars(str)) {
+      updatedCharBufPtr = (void *)JS::GetLatin1LinearStringChars(nogc, str);
+    } else { // utf16 / ucs2 string
+      updatedCharBufPtr = (void *)JS::GetTwoByteLinearStringChars(nogc, str);
+    }
+    ((PyUnicodeObject *)(jsStringProxy))->data.any = updatedCharBufPtr;
+  }
+}
+
 void pythonmonkeyGCCallback(JSContext *cx, JSGCStatus status, JS::GCReason reason, void *data) {
   if (status == JSGCStatus::JSGC_END) {
     JS::ClearKeptObjects(GLOBAL_CX);
     while (JOB_QUEUE->runFinalizationRegistryCallbacks(GLOBAL_CX));
+    updateCharBufferPointers();
+  }
+}
 
-    if (_Py_IsFinalizing()) {
-      return; // do not move char pointers around if python is finalizing
-    }
-
-    JS::AutoCheckCannotGC nogc;
-    for (const JSStringProxy *jsStringProxy: jsStringProxies) { // char buffers may have moved, so we need to re-point our JSStringProxies
-      JSLinearString *str = (JSLinearString *)(jsStringProxy->jsString->toString()); // jsString is guaranteed to be linear
-      if (JS::LinearStringHasLatin1Chars(str)) {
-        (((PyUnicodeObject *)(jsStringProxy))->data.any) = (void *)JS::GetLatin1LinearStringChars(nogc, str);
-      }
-      else { // utf16 / ucs2 string
-        (((PyUnicodeObject *)(jsStringProxy))->data.any) = (void *)JS::GetTwoByteLinearStringChars(nogc, str);
-      }
-    }
+void nurseryCollectionCallback(JSContext *cx, JS::GCNurseryProgress progress, JS::GCReason reason, void *data) {
+  if (progress == JS::GCNurseryProgress::GC_NURSERY_COLLECTION_END) {
+    updateCharBufferPointers();
   }
 }
 
@@ -565,6 +579,7 @@ PyMODINIT_FUNC PyInit_pythonmonkey(void)
   JS_SetGCParameter(GLOBAL_CX, JSGC_MAX_BYTES, (uint32_t)-1);
 
   JS_SetGCCallback(GLOBAL_CX, pythonmonkeyGCCallback, NULL);
+  JS::AddGCNurseryCollectionCallback(GLOBAL_CX, nurseryCollectionCallback, NULL);
 
   JS::RealmCreationOptions creationOptions = JS::RealmCreationOptions();
   JS::RealmBehaviors behaviours = JS::RealmBehaviors();


### PR DESCRIPTION
String buffers memory would be moved around during a **minor GC (nursery collection)**.

The string buffer pointer obtained by `JS::Get{Latin1,TwoByte}LinearStringChars` remains valid only as long as no GC happens.
Even though `JS::PersistentRootedValue` does keep the string buffer from being garbage-collected, it does not guarantee the buffer would not be moved elsewhere during a GC, and so invalidates the string buffer pointer.

---

The direction of @caleb-distributive's fix in PR https://github.com/Distributive-Network/PythonMonkey/pull/417 is correct.
> Finally, it adds a GC callback that re-points all of the JSStringProxy data pointers to their associated data, since they may have moved during a GC.

However, from my testing, moving string buffers only happens during **nursery collections** (minor GC, hooked by `JS::AddGCNurseryCollectionCallback`).
The [changes in PR 417](https://github.com/Distributive-Network/PythonMonkey/pull/417/commits/75141d878fdfe5a9b805235cd98fefcdaf10a9c6) only check if the memory address of string buffers has changed during a **full GC** (hooked by `JS_SetGCCallback`).
Nursery collections can happen much more frequently than full GCs.

Also, https://bugzilla.mozilla.org/show_bug.cgi?id=1880044 might have changed the behaviour for garbage collection of string buffers. The [latest SpiderMonkey commit](https://hg.mozilla.org/mozilla-central/rev/971125148077) on mozilla-central has landed changes to allocate flattened string buffers in the nursery.

---

This PR would solve the root cause of the following issues: (All because of the string corruption bug)

* Closes https://github.com/Distributive-Network/PythonMonkey/issues/340
* Closes https://github.com/Distributive-Network/PythonMonkey/issues/332
* Closes https://github.com/Distributive-Network/PythonMonkey/issues/366