### PR TITLE
Fix remaining memory bugs

### DIFF
--- a/include/StrType.hh
+++ b/include/StrType.hh
@@ -36,8 +36,6 @@ public:
    */
   static PyObject *getPyObject(JSContext *cx, JS::HandleValue str);
 
-  static const char *getValue(JSContext *cx, JS::HandleValue str);
-
   static PyObject *proxifyString(JSContext *cx, JS::HandleValue str);
 };
 

--- a/python/pythonmonkey/require.py
+++ b/python/pythonmonkey/require.py
@@ -85,8 +85,8 @@ globalThis.python.stderr.read = lambda n: sys.stderr.read(n)
 # Python 3.13 dramatically changed how the namespace in `exec`/`eval` works
 # See https://docs.python.org/3.13/whatsnew/3.13.html#defined-mutation-semantics-for-locals
 _locals = {}  # keep the local variables inside `eval`/`exec` to a dict
-globalThis.python.eval = lambda x: eval(x, None, _locals)
-globalThis.python.exec = lambda x: exec(x, None, _locals)
+globalThis.python.eval = lambda x: eval(str(x)[:], None, _locals)
+globalThis.python.exec = lambda x: exec(str(x)[:], None, _locals)
 globalThis.python.getenv = os.getenv
 globalThis.python.paths = sys.path
 

--- a/src/ExceptionType.cc
+++ b/src/ExceptionType.cc
@@ -107,8 +107,8 @@ JSObject *ExceptionType::toJsError(JSContext *cx, PyObject *exceptionValue, PyOb
   if (stackObj.get()) {
     JS::RootedString stackStr(cx);
     JS::BuildStackString(cx, nullptr, stackObj, &stackStr, 2, js::StackFormat::SpiderMonkey);
-    JS::RootedValue stackStrVal(cx, JS::StringValue(stackStr));
-    stackStream << "\nJS Stack Trace:\n" << StrType::getValue(cx, stackStrVal);
+    JS::UniqueChars stackStrUtf8 = JS_EncodeStringToUTF8(cx, stackStr);
+    stackStream << "\nJS Stack Trace:\n" << stackStrUtf8.get();
   }
 
 

--- a/src/JSObjectProxy.cc
+++ b/src/JSObjectProxy.cc
@@ -36,9 +36,10 @@ JSContext *GLOBAL_CX; /**< pointer to PythonMonkey's JSContext */
 bool keyToId(PyObject *key, JS::MutableHandleId idp) {
   if (PyUnicode_Check(key)) { // key is str type
     JS::RootedString idString(GLOBAL_CX);
-    const char *keyStr = PyUnicode_AsUTF8(key);
-    JS::ConstUTF8CharsZ utf8Chars(keyStr, strlen(keyStr));
-    idString.set(JS_NewStringCopyUTF8Z(GLOBAL_CX, utf8Chars));
+    Py_ssize_t length;
+    const char *keyStr = PyUnicode_AsUTF8AndSize(key, &length);
+    JS::UTF8Chars utf8Chars(keyStr, length);
+    idString.set(JS_NewStringCopyUTF8N(GLOBAL_CX, utf8Chars));
     return JS_StringToId(GLOBAL_CX, idString, idp);
   } else if (PyLong_Check(key)) { // key is int type
     uint32_t keyAsInt = PyLong_AsUnsignedLong(key); // TODO raise OverflowError if the value of pylong is out of range for a unsigned long

--- a/src/JSObjectProxy.cc
+++ b/src/JSObjectProxy.cc
@@ -638,6 +638,7 @@ skip_optional:
 
   PyObject *value = JSObjectProxy_get(self, key);
   if (value == Py_None) {
+    Py_INCREF(default_value);
     value = default_value;
   }
 

--- a/src/JobQueue.cc
+++ b/src/JobQueue.cc
@@ -121,6 +121,7 @@ bool sendJobToMainLoop(PyObject *pyFunc) {
   }
   loop.enqueue(pyFunc);
 
+  loop._loop = nullptr; // the `Py_XDECREF` Python API call in `PyEventLoop`'s destructor will not be accessible once we hand over the GIL by `PyGILState_Release`
   PyGILState_Release(gstate);
   return true;
 }

--- a/src/PyBytesProxyHandler.cc
+++ b/src/PyBytesProxyHandler.cc
@@ -415,6 +415,9 @@ bool PyBytesProxyHandler::getOwnPropertyDescriptor(
   PyObject *attrName = idToKey(cx, id);
   PyObject *self = JS::GetMaybePtrFromReservedSlot<PyObject>(proxy, PyObjectSlot);
   PyObject *item = PyObject_GetAttr(self, attrName);
+  if (!item && PyErr_ExceptionMatches(PyExc_AttributeError)) {
+    PyErr_Clear(); // clear error, we will be returning undefined in this case
+  }
 
   return handleGetOwnPropertyDescriptor(cx, id, desc, item);
 }

--- a/src/PyDictProxyHandler.cc
+++ b/src/PyDictProxyHandler.cc
@@ -56,7 +56,7 @@ bool PyDictProxyHandler::getOwnPropertyDescriptor(
 ) const {
   PyObject *attrName = idToKey(cx, id);
   PyObject *self = JS::GetMaybePtrFromReservedSlot<PyObject>(proxy, PyObjectSlot);
-  PyObject *item = PyDict_GetItemWithError(self, attrName);
+  PyObject *item = PyDict_GetItemWithError(self, attrName); // returns NULL without an exception set if the key wasn’t present.
 
   return handleGetOwnPropertyDescriptor(cx, id, desc, item);
 }

--- a/src/PyIterableProxyHandler.cc
+++ b/src/PyIterableProxyHandler.cc
@@ -79,7 +79,7 @@ static bool toPrimitive(JSContext *cx, unsigned argc, JS::Value *vp) {
   _PyUnicodeWriter writer;
 
   _PyUnicodeWriter_Init(&writer);
-  
+
   PyObject *s = PyObject_Repr(self);
 
   if (s == nullptr) {
@@ -95,8 +95,8 @@ static bool toPrimitive(JSContext *cx, unsigned argc, JS::Value *vp) {
     return true;
   }
 
-  PyObject* repr = _PyUnicodeWriter_Finish(&writer);
- 
+  PyObject *repr = _PyUnicodeWriter_Finish(&writer);
+
   args.rval().set(jsTypeFactory(cx, repr));
   return true;
 }
@@ -262,7 +262,7 @@ bool PyIterableProxyHandler::getOwnPropertyDescriptor(
   // symbol property
   if (id.isSymbol()) {
     JS::RootedSymbol rootedSymbol(cx, id.toSymbol());
-    JS::SymbolCode symbolCode = JS::GetSymbolCode(rootedSymbol); 
+    JS::SymbolCode symbolCode = JS::GetSymbolCode(rootedSymbol);
 
     if (symbolCode == JS::SymbolCode::iterator) {
       JSFunction *newFunction = JS_NewFunction(cx, iterable_values, 0, 0, NULL);
@@ -275,7 +275,7 @@ bool PyIterableProxyHandler::getOwnPropertyDescriptor(
         )
       ));
       return true;
-    } 
+    }
     else if (symbolCode == JS::SymbolCode::toPrimitive) {
       JSFunction *newFunction = JS_NewFunction(cx, toPrimitive, 0, 0, nullptr);
       if (!newFunction) return false;
@@ -293,6 +293,9 @@ bool PyIterableProxyHandler::getOwnPropertyDescriptor(
   PyObject *attrName = idToKey(cx, id);
   PyObject *self = JS::GetMaybePtrFromReservedSlot<PyObject>(proxy, PyObjectSlot);
   PyObject *item = PyObject_GetAttr(self, attrName);
+  if (!item && PyErr_ExceptionMatches(PyExc_AttributeError)) {
+    PyErr_Clear(); // clear error, we will be returning undefined in this case
+  }
 
   return handleGetOwnPropertyDescriptor(cx, id, desc, item);
 }

--- a/src/PyListProxyHandler.cc
+++ b/src/PyListProxyHandler.cc
@@ -550,15 +550,7 @@ static bool array_concat(JSContext *cx, unsigned argc, JS::Value *vp) {
   PyObject *self = JS::GetMaybePtrFromReservedSlot<PyObject>(proxy, PyObjectSlot);
 
   Py_ssize_t selfSize = PyList_GET_SIZE(self);
-
-  PyObject *result = PyList_New(selfSize);
-
-  // Copy items to the new list
-  for (Py_ssize_t index = 0; index < selfSize; index++) {
-    PyObject *item = PyList_GetItem(self, index);
-    Py_INCREF(item); // `PyList_SetItem` steals the reference, so we must increase the reference count by 1
-    PyList_SetItem(result, index, item);
-  }
+  PyObject *result = PyList_GetSlice(self, 0, selfSize);
 
   unsigned numArgs = args.length();
   JS::RootedValue elementVal(cx);

--- a/src/PyListProxyHandler.cc
+++ b/src/PyListProxyHandler.cc
@@ -553,8 +553,11 @@ static bool array_concat(JSContext *cx, unsigned argc, JS::Value *vp) {
 
   PyObject *result = PyList_New(selfSize);
 
+  // Copy items to the new list
   for (Py_ssize_t index = 0; index < selfSize; index++) {
-    PyList_SetItem(result, index, PyList_GetItem(self, index));
+    PyObject *item = PyList_GetItem(self, index);
+    Py_INCREF(item); // `PyList_SetItem` steals the reference, so we must increase the reference count by 1
+    PyList_SetItem(result, index, item);
   }
 
   unsigned numArgs = args.length();

--- a/src/PyListProxyHandler.cc
+++ b/src/PyListProxyHandler.cc
@@ -436,8 +436,9 @@ static bool array_fill(JSContext *cx, unsigned argc, JS::Value *vp) {
     }
   }
 
-  if (!setItemCalled) {
-    Py_DECREF(fillValueItem);
+  Py_INCREF(fillValueItem);
+  if (setItemCalled) {
+    Py_INCREF(fillValueItem);
   }
 
   // return ref to self

--- a/src/PyObjectProxyHandler.cc
+++ b/src/PyObjectProxyHandler.cc
@@ -143,8 +143,8 @@ bool PyObjectProxyHandler::getOwnPropertyDescriptor(
   PyObject *attrName = idToKey(cx, id);
   PyObject *self = JS::GetMaybePtrFromReservedSlot<PyObject>(proxy, PyObjectSlot);
   PyObject *item = PyObject_GetAttr(self, attrName);
-  if (!item) { // clear error, we will be returning undefined in this case
-    PyErr_Clear();
+  if (!item && PyErr_ExceptionMatches(PyExc_AttributeError)) {
+    PyErr_Clear(); // clear error, we will be returning undefined in this case
   }
 
   return handleGetOwnPropertyDescriptor(cx, id, desc, item);

--- a/src/StrType.cc
+++ b/src/StrType.cc
@@ -212,10 +212,3 @@ PyObject *StrType::getPyObject(JSContext *cx, JS::HandleValue str) {
 
   return proxifyString(cx, str);
 }
-
-const char *StrType::getValue(JSContext *cx, JS::HandleValue str) {
-  PyObject *pyString = proxifyString(cx, str);
-  const char *value = PyUnicode_AsUTF8(PyUnicode_FromObject(pyString));
-  Py_DECREF(pyString);
-  return value;
-}

--- a/src/modules/pythonmonkey/pythonmonkey.cc
+++ b/src/modules/pythonmonkey/pythonmonkey.cc
@@ -461,8 +461,9 @@ static PyObject *eval(PyObject *self, PyObject *args) {
   JS::Rooted<JS::Value> rval(GLOBAL_CX);
   if (code) {
     JS::SourceText<mozilla::Utf8Unit> source;
-    const char *codeChars = PyUnicode_AsUTF8(code);
-    if (!source.init(GLOBAL_CX, codeChars, strlen(codeChars), JS::SourceOwnership::Borrowed)) {
+    Py_ssize_t codeLength;
+    const char *codeChars = PyUnicode_AsUTF8AndSize(code, &codeLength);
+    if (!source.init(GLOBAL_CX, codeChars, codeLength, JS::SourceOwnership::Borrowed)) {
       setSpiderMonkeyException(GLOBAL_CX);
       return NULL;
     }
@@ -521,9 +522,10 @@ static PyObject *isCompilableUnit(PyObject *self, PyObject *args) {
     return NULL;
   }
 
-  const char *bufferUtf8 = PyUnicode_AsUTF8(item);
+  Py_ssize_t bufferLength;
+  const char *bufferUtf8 = PyUnicode_AsUTF8AndSize(item, &bufferLength);
 
-  if (JS_Utf8BufferIsCompilableUnit(GLOBAL_CX, *global, bufferUtf8, strlen(bufferUtf8))) {
+  if (JS_Utf8BufferIsCompilableUnit(GLOBAL_CX, *global, bufferUtf8, bufferLength)) {
     Py_RETURN_TRUE;
   } else {
     Py_RETURN_FALSE;

--- a/src/modules/pythonmonkey/pythonmonkey.cc
+++ b/src/modules/pythonmonkey/pythonmonkey.cc
@@ -331,7 +331,7 @@ static bool getEvalOption(PyObject *evalOptions, const char *optionName, const c
     value = PyDict_GetItemString(evalOptions, optionName);
   }
   if (value && value != Py_None) {
-    *s_p = PyUnicode_AsUTF8(value);
+    *s_p = PyUnicode_AsUTF8(PyUnicode_FromObject(value));
   }
   return value != NULL && value != Py_None;
 }
@@ -449,7 +449,8 @@ static PyObject *eval(PyObject *self, PyObject *args) {
 #endif
       if (!getEvalOption(evalOptions, "filename", &s)) {
         if (filename && PyUnicode_Check(filename)) {
-          options.setFile(PyUnicode_AsUTF8(filename));
+          PyObject *filenameStr = PyUnicode_FromObject(filename); // needs a strict Python str object (not a subtype)
+          options.setFile(PyUnicode_AsUTF8(filenameStr));
         }
       } /* filename */
     } /* fromPythonFrame */

--- a/src/modules/pythonmonkey/pythonmonkey.cc
+++ b/src/modules/pythonmonkey/pythonmonkey.cc
@@ -303,8 +303,6 @@ PyTypeObject JSObjectItemsProxyType = {
 };
 
 static void cleanup() {
-  Py_XDECREF(PythonMonkey_Null);
-  Py_XDECREF(PythonMonkey_BigInt);
   delete autoRealm;
   delete global;
   if (GLOBAL_CX) JS_DestroyContext(GLOBAL_CX);

--- a/src/modules/pythonmonkey/pythonmonkey.cc
+++ b/src/modules/pythonmonkey/pythonmonkey.cc
@@ -310,7 +310,10 @@ static void cleanup() {
   // Clean up SpiderMonkey
   delete autoRealm;
   delete global;
-  if (GLOBAL_CX) JS_DestroyContext(GLOBAL_CX);
+  if (GLOBAL_CX) {
+    JS_DestroyContext(GLOBAL_CX);
+    GLOBAL_CX = nullptr;
+  }
   delete JOB_QUEUE;
   JS_ShutDown();
 }

--- a/src/setSpiderMonkeyException.cc
+++ b/src/setSpiderMonkeyException.cc
@@ -66,8 +66,8 @@ PyObject *getExceptionString(JSContext *cx, const JS::ExceptionStack &exceptionS
     if (stackObj.get()) {
       JS::RootedString stackStr(cx);
       BuildStackString(cx, nullptr, stackObj, &stackStr, 2, js::StackFormat::SpiderMonkey);
-      JS::RootedValue stackStrVal(cx, JS::StringValue(stackStr));
-      outStrStream << "Stack Trace:\n" << StrType::getValue(cx, stackStrVal);
+      JS::UniqueChars stackStrUtf8 = JS_EncodeStringToUTF8(cx, stackStr);
+      outStrStream << "Stack Trace:\n" << stackStrUtf8.get();
     }
   }
 


### PR DESCRIPTION
The CI sometimes [fail on `main`](https://github.com/Distributive-Network/PythonMonkey/actions/runs/11002881033/job/30550821137) even after we released the "stable" PythonMonkey v1.0.

After all pytests are done, the program segfaults during the Python interpreter finalization.

```console
============================= 678 passed in 23.59s =============================
/Users/runner/work/_temp/cab3e84e-a831-4a41-9c31-79102f1651a5.sh: line 7:  5781 Segmentation fault: 11  (core dumped) poetry run python -m pytest tests/python
```


---
 
Debugged using a debug build of Python