### PR TITLE
Chore: update package information

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,12 @@
 [tool.poetry]
 name = "pythonmonkey"
 version = "0" # automatically set by poetry-dynamic-versioning
-description = ""
-authors = ["Caleb Aikens <caleb@distributive.network>", "Tom Tang <xmader@distributive.network>", "Wes Garland <wes@distributive.network>", "Hamada Gasmallah <hamada@distributive.network>", "Philippe Laporte <philippe@distributive.network>"]
+description = "Seamless interop between Python and JavaScript."
+authors = ["Distributive Corp. <pm@distributive.network>"]
+license = "MIT"
+homepage = "https://pythonmonkey.io/"
+documentation = "https://docs.pythonmonkey.io/"
+repository = "https://github.com/Distributive-Network/PythonMonkey"
 readme = "README.md"
 packages = [
   { include = "pythonmonkey", from = "python" },


### PR DESCRIPTION
Update the PKG-INFO `pip show pythonmonkey` would give.

* Change the authors field to `Distributive Corp.`
* Add project description
* Add the MIT license
* Add links to our homepage and GitHub repo etc.