### PR TITLE
chore(CI): use GitHub-hosted runners for Linux arm64

### DIFF
--- a/.github/workflows/test-and-publish.yaml
+++ b/.github/workflows/test-and-publish.yaml
@@ -65,8 +65,8 @@ jobs:
       fail-fast: false
       matrix:
         # Use Ubuntu 20.04 / macOS 13 x86_64 / macOS 14 arm64 + Python 3.10 to build SpiderMonkey
-        os: [ 'ubuntu-20.04', 'macos-13', 'macos-14', 'pi' ] # macOS 14 runner exclusively runs on M1 hardwares
-                                                             # see https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available
+        os: [ 'ubuntu-20.04', 'macos-13', 'macos-14', 'ubuntu-22.04-arm' ] # macOS 14 runner exclusively runs on M1 hardwares
+                                                                           # see https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available
         python_version: [ '3.10' ]
     runs-on: ${{ matrix.os }}
     steps:
@@ -132,7 +132,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ 'ubuntu-20.04', 'macos-13', 'macos-14', 'windows-2022', 'pi' ]
+        os: [ 'ubuntu-20.04', 'macos-13', 'macos-14', 'windows-2022', 'ubuntu-22.04-arm' ]
         python_version: [ '3.8', '3.9', '3.10', '3.11', '3.12', '3.13' ]
     runs-on: ${{ matrix.os }}
     steps:
@@ -144,9 +144,6 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python_version }}
-      - name: Remove old poetry cache
-        run: rm -rf ~/.cache/pypoetry
-        if: ${{ matrix.os == 'pi' }}
       - name: Setup Poetry
         uses: snok/install-poetry@v1
         with:


### PR DESCRIPTION
So that we don't have to maintain a Ubuntu VM inside of the office M1 mac mini. 
And forkers can run the CI by themselves.