### PR TITLE
CI: Build on Ubuntu 20.04 for arm64 linux release

### DIFF
--- a/.github/workflows/test-and-publish.yaml
+++ b/.github/workflows/test-and-publish.yaml
@@ -95,6 +95,7 @@ jobs:
       - name: Setup LLVM
         if: ${{ startsWith(matrix.os, 'ubuntu') && steps.cache-spidermonkey.outputs.cache-hit != 'true' }}
         run: |
+          apt-get install -y clang clang++
           apt-get install -y lsb-release wget software-properties-common gnupg
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
@@ -102,6 +103,8 @@ jobs:
           update-alternatives --install /usr/bin/llvm-config llvm-config /usr/bin/llvm-config-18 18
           update-alternatives --install /usr/bin/clang clang /usr/bin/clang-18 18
           update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-18 18
+          clang --version
+          clang++ --version
       - name: Setup Python
         if: ${{ startsWith(matrix.os, 'ubuntu') && steps.cache-spidermonkey.outputs.cache-hit != 'true' }}
         run: |

--- a/.github/workflows/test-and-publish.yaml
+++ b/.github/workflows/test-and-publish.yaml
@@ -96,9 +96,10 @@ jobs:
         if: ${{ startsWith(matrix.os, 'ubuntu') && steps.cache-spidermonkey.outputs.cache-hit != 'true' }}
         run: |
           apt-get install -y lsb-release wget software-properties-common gnupg
-          wget https://apt.llvm.org/llvm.sh
-          chmod +x llvm.sh
-          ./llvm.sh 18 # install LLVM version 18
+          echo "deb http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs) main" | tee -a /etc/apt/sources.list.d/llvm.list
+          echo "deb http://apt.llvm.org/$(lsb_release -cs)/ llvm-defaults main" | tee -a /etc/apt/sources.list.d/llvm.list
+          apt-get update -y
+          apt-get install -y llvm-defaults clang
       - name: Setup Python
         if: ${{ startsWith(matrix.os, 'ubuntu') && steps.cache-spidermonkey.outputs.cache-hit != 'true' }}
         run: |

--- a/.github/workflows/test-and-publish.yaml
+++ b/.github/workflows/test-and-publish.yaml
@@ -92,6 +92,12 @@ jobs:
           apt-get install -y zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev # required for pyenv
           DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata
           echo "AGENT_TOOLSDIRECTORY=/" >> $GITHUB_ENV # do not use the Python installation cached for Ubuntu 22.04
+      - name: Setup LLVM
+        if: ${{ startsWith(matrix.os, 'ubuntu') && steps.cache-spidermonkey.outputs.cache-hit != 'true' }}
+        run: |
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          ./llvm.sh 18 # install LLVM version 18
       - name: Setup Python
         if: ${{ startsWith(matrix.os, 'ubuntu') && steps.cache-spidermonkey.outputs.cache-hit != 'true' }}
         run: |

--- a/.github/workflows/test-and-publish.yaml
+++ b/.github/workflows/test-and-publish.yaml
@@ -161,7 +161,7 @@ jobs:
         run: |
           apt-get update -y
           apt-get install -y sudo libnss3-dev libssl-dev
-          apt-get install -y curl python3 zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev # required for pyenv
+          apt-get install -y curl zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev # required for pyenv
           apt-get install -y git # required for `actions/checkout`
           apt-get install -y nodejs npm # required for pminit to build
           apt-get install -y build-essential
@@ -186,9 +186,9 @@ jobs:
           # Use pyenv to install Python version that is not available via `actions/setup-python`
           unset PYENV_ROOT
           curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash
-          echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc
-          echo '[[ -d $PYENV_ROOT/bin ]] && export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc
-          echo 'eval "$(pyenv init - bash)"' >> ~/.bashrc
+          echo "$HOME/.pyenv/bin" >> $GITHUB_PATH # ~/.bashrc file is not read, so we need to add to GITHUB_PATH manually
+          echo "$HOME/.pyenv/shims" >> $GITHUB_PATH
+          echo "PYENV_ROOT=$HOME/.pyenv" >> $GITHUB_ENV
           export PATH="$HOME/.pyenv/bin:$PATH"
           pyenv install $PYTHON_VERSION
           pyenv global $PYTHON_VERSION
@@ -199,14 +199,12 @@ jobs:
         with:
           python-version: ${{ matrix.python_version }}
       - run: |
-          source ~/.bashrc || true # load pyenv into the current shell
           python --version
           python3 --version
       - name: Setup Poetry
         uses: snok/install-poetry@v1
         with:
           version: 1.5.1
-          virtualenvs-create: false
       - name: Install Dependencies
         run: |
           echo "Installing Dependencies"

--- a/.github/workflows/test-and-publish.yaml
+++ b/.github/workflows/test-and-publish.yaml
@@ -95,7 +95,7 @@ jobs:
       - name: Setup LLVM
         if: ${{ startsWith(matrix.os, 'ubuntu') && steps.cache-spidermonkey.outputs.cache-hit != 'true' }}
         run: |
-          apt-get install -y clang clang++
+          apt-get install -y llvm clang
           apt-get install -y lsb-release wget software-properties-common gnupg
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh

--- a/.github/workflows/test-and-publish.yaml
+++ b/.github/workflows/test-and-publish.yaml
@@ -71,7 +71,7 @@ jobs:
                                                                            # see https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available
         python_version: [ '3.10' ]
     runs-on: ${{ matrix.os }}
-    container: ${{ (matrix.os == 'ubuntu-22.04' && 'ubuntu:20.04') || null }} # Use the Ubuntu 20.04 container inside Ubuntu 22.04 runner to build
+    container: ${{ ( runner.os == 'Linux' && 'ubuntu:20.04') || null }} # Use the Ubuntu 20.04 container inside Ubuntu 22.04 runner to build
     steps:
       - uses: actions/checkout@v4
       - name: Read the mozilla-central commit hash to be used
@@ -84,14 +84,29 @@ jobs:
             ./_spidermonkey_install/*
           key: spidermonkey-${{ env.MOZCENTRAL_VERSION }}-${{ runner.os }}-${{ runner.arch }}
       - name: Setup container
-        if: ${{ matrix.os == 'ubuntu-22.04' && steps.cache-spidermonkey.outputs.cache-hit != 'true' }}
+        if: ${{ runner.os == 'Linux' && steps.cache-spidermonkey.outputs.cache-hit != 'true' }}
         run: |
           apt-get update -y
           apt-get install -y sudo libnss3-dev libssl-dev
+          apt-get install -y curl zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev # required for pyenv
           DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata
           echo "AGENT_TOOLSDIRECTORY=/" >> $GITHUB_ENV # do not use the Python installation cached for Ubuntu 22.04
+      - name: Setup Python
+        if: ${{ runner.os == 'Linux' && steps.cache-spidermonkey.outputs.cache-hit != 'true' }}
+        run: |
+          # Use pyenv to install Python version that is not available via `actions/setup-python`
+          unset PYENV_ROOT
+          curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash
+          echo "$HOME/.pyenv/bin" >> $GITHUB_PATH # ~/.bashrc file is not read, so we need to add to GITHUB_PATH manually
+          echo "$HOME/.pyenv/shims" >> $GITHUB_PATH
+          echo "PYENV_ROOT=$HOME/.pyenv" >> $GITHUB_ENV
+          export PATH="$HOME/.pyenv/bin:$PATH"
+          pyenv install $PYTHON_VERSION
+          pyenv global $PYTHON_VERSION
+        env:
+          PYTHON_VERSION: ${{ matrix.python_version }}
       - uses: actions/setup-python@v5
-        if: ${{ steps.cache-spidermonkey.outputs.cache-hit != 'true' }}
+        if: ${{ runner.os != 'Linux' && steps.cache-spidermonkey.outputs.cache-hit != 'true' }}
         with:
           python-version: ${{ matrix.python_version }}
       - name: Setup XCode
@@ -154,10 +169,10 @@ jobs:
         os: [ 'ubuntu-22.04', 'macos-13', 'macos-14', 'windows-2022', 'ubuntu-22.04-arm' ]
         python_version: [ '3.8', '3.9', '3.10', '3.11', '3.12', '3.13' ]
     runs-on: ${{ matrix.os }}
-    container: ${{ (matrix.os == 'ubuntu-22.04' && 'ubuntu:20.04') || null }}
+    container: ${{ (runner.os == 'Linux' && 'ubuntu:20.04') || null }}
     steps:
       - name: Setup container
-        if: ${{ matrix.os == 'ubuntu-22.04' }}
+        if: ${{ runner.os == 'Linux' }}
         run: |
           apt-get update -y
           apt-get install -y sudo libnss3-dev libssl-dev
@@ -198,9 +213,6 @@ jobs:
         if: ${{ runner.os != 'Linux' }}
         with:
           python-version: ${{ matrix.python_version }}
-      - run: |
-          python --version
-          python3 --version
       - name: Setup Poetry
         uses: snok/install-poetry@v1
         with:

--- a/.github/workflows/test-and-publish.yaml
+++ b/.github/workflows/test-and-publish.yaml
@@ -160,7 +160,8 @@ jobs:
         if: ${{ matrix.os == 'ubuntu-22.04' }}
         run: |
           apt-get update -y
-          apt-get install -y sudo libnss3-dev libssl-dev
+          apt-get install -y sudo curl libnss3-dev libssl-dev
+          apt-get install -y zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev # required for pyenv
           apt-get install -y git # required for `actions/checkout`
           apt-get install -y nodejs npm # required for pminit to build
           apt-get install -y build-essential

--- a/.github/workflows/test-and-publish.yaml
+++ b/.github/workflows/test-and-publish.yaml
@@ -88,7 +88,8 @@ jobs:
         run: |
           apt-get update -y
           apt-get install -y sudo libnss3-dev libssl-dev
-          apt-get install -y curl zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev # required for pyenv
+          apt-get install -y curl make git build-essential
+          apt-get install -y zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev # required for pyenv
           DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata
           echo "AGENT_TOOLSDIRECTORY=/" >> $GITHUB_ENV # do not use the Python installation cached for Ubuntu 22.04
       - name: Setup Python

--- a/.github/workflows/test-and-publish.yaml
+++ b/.github/workflows/test-and-publish.yaml
@@ -95,7 +95,7 @@ jobs:
       - name: Setup LLVM
         if: ${{ startsWith(matrix.os, 'ubuntu') && steps.cache-spidermonkey.outputs.cache-hit != 'true' }}
         run: |
-          apt-get install -y lsb-release wget
+          apt-get install -y lsb-release wget software-properties-common gnupg
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
           ./llvm.sh 18 # install LLVM version 18

--- a/.github/workflows/test-and-publish.yaml
+++ b/.github/workflows/test-and-publish.yaml
@@ -160,8 +160,8 @@ jobs:
         if: ${{ matrix.os == 'ubuntu-22.04' }}
         run: |
           apt-get update -y
-          apt-get install -y sudo curl libnss3-dev libssl-dev
-          apt-get install -y zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev # required for pyenv
+          apt-get install -y sudo libnss3-dev libssl-dev
+          apt-get install -y curl python3 zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev # required for pyenv
           apt-get install -y git # required for `actions/checkout`
           apt-get install -y nodejs npm # required for pminit to build
           apt-get install -y build-essential

--- a/.github/workflows/test-and-publish.yaml
+++ b/.github/workflows/test-and-publish.yaml
@@ -88,13 +88,14 @@ jobs:
         run: |
           apt-get update -y
           apt-get install -y sudo libnss3-dev libssl-dev
-          apt-get install -y curl wget make git build-essential
+          apt-get install -y curl make git build-essential
           apt-get install -y zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev # required for pyenv
           DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata
           echo "AGENT_TOOLSDIRECTORY=/" >> $GITHUB_ENV # do not use the Python installation cached for Ubuntu 22.04
       - name: Setup LLVM
         if: ${{ startsWith(matrix.os, 'ubuntu') && steps.cache-spidermonkey.outputs.cache-hit != 'true' }}
         run: |
+          apt-get install -y lsb-release wget
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
           ./llvm.sh 18 # install LLVM version 18

--- a/.github/workflows/test-and-publish.yaml
+++ b/.github/workflows/test-and-publish.yaml
@@ -187,6 +187,7 @@ jobs:
           echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc
           echo '[[ -d $PYENV_ROOT/bin ]] && export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc
           echo 'eval "$(pyenv init - bash)"' >> ~/.bashrc
+          source ~/.bashrc
           pyenv install $PYTHON_VERSION
           pyenv global $PYTHON_VERSION
         env:

--- a/.github/workflows/test-and-publish.yaml
+++ b/.github/workflows/test-and-publish.yaml
@@ -198,10 +198,15 @@ jobs:
         if: ${{ runner.os != 'Linux' }}
         with:
           python-version: ${{ matrix.python_version }}
+      - run: |
+          source ~/.bashrc || true # load pyenv into the current shell
+          python --version
+          python3 --version
       - name: Setup Poetry
         uses: snok/install-poetry@v1
         with:
           version: 1.5.1
+          virtualenvs-create: false
       - name: Install Dependencies
         run: |
           echo "Installing Dependencies"

--- a/.github/workflows/test-and-publish.yaml
+++ b/.github/workflows/test-and-publish.yaml
@@ -179,7 +179,20 @@ jobs:
           submodules: recursive
           fetch-depth: 0 # fetch all history for all branches and tags
           # poetry-dynamic-versioning needs git tags to produce the correct version number 
+      - name: Setup Python
+        if: ${{ runner.os == 'Linux' }}
+        run: |
+          # Use pyenv to install Python version that is not available via `actions/setup-python`
+          curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash
+          echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc
+          echo '[[ -d $PYENV_ROOT/bin ]] && export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc
+          echo 'eval "$(pyenv init - bash)"' >> ~/.bashrc
+          pyenv install $PYTHON_VERSION
+          pyenv global $PYTHON_VERSION
+        env:
+          PYTHON_VERSION: ${{ matrix.python_version }}
       - uses: actions/setup-python@v5
+        if: ${{ runner.os != 'Linux' }}
         with:
           python-version: ${{ matrix.python_version }}
       - name: Setup Poetry

--- a/.github/workflows/test-and-publish.yaml
+++ b/.github/workflows/test-and-publish.yaml
@@ -88,7 +88,7 @@ jobs:
         run: |
           apt-get update -y
           apt-get install -y sudo libnss3-dev libssl-dev
-          apt-get install -y curl make git build-essential
+          apt-get install -y curl wget make git build-essential
           apt-get install -y zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev # required for pyenv
           DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata
           echo "AGENT_TOOLSDIRECTORY=/" >> $GITHUB_ENV # do not use the Python installation cached for Ubuntu 22.04

--- a/.github/workflows/test-and-publish.yaml
+++ b/.github/workflows/test-and-publish.yaml
@@ -96,10 +96,12 @@ jobs:
         if: ${{ startsWith(matrix.os, 'ubuntu') && steps.cache-spidermonkey.outputs.cache-hit != 'true' }}
         run: |
           apt-get install -y lsb-release wget software-properties-common gnupg
-          echo "deb http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs) main" | tee -a /etc/apt/sources.list.d/llvm.list
-          echo "deb http://apt.llvm.org/$(lsb_release -cs)/ llvm-defaults main" | tee -a /etc/apt/sources.list.d/llvm.list
-          apt-get update -y
-          apt-get install -y llvm-defaults clang
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          ./llvm.sh 18 # install LLVM version 18
+          update-alternatives --install /usr/bin/llvm-config llvm-config /usr/bin/llvm-config-18 18
+          update-alternatives --install /usr/bin/clang clang /usr/bin/clang-18 18
+          update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-18 18
       - name: Setup Python
         if: ${{ startsWith(matrix.os, 'ubuntu') && steps.cache-spidermonkey.outputs.cache-hit != 'true' }}
         run: |

--- a/.github/workflows/test-and-publish.yaml
+++ b/.github/workflows/test-and-publish.yaml
@@ -71,7 +71,7 @@ jobs:
                                                                            # see https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available
         python_version: [ '3.10' ]
     runs-on: ${{ matrix.os }}
-    container: ${{ ( runner.os == 'Linux' && 'ubuntu:20.04') || null }} # Use the Ubuntu 20.04 container inside Ubuntu 22.04 runner to build
+    container: ${{ (startsWith(matrix.os, 'ubuntu') && 'ubuntu:20.04') || null }} # Use the Ubuntu 20.04 container inside Ubuntu 22.04 runner to build
     steps:
       - uses: actions/checkout@v4
       - name: Read the mozilla-central commit hash to be used
@@ -84,7 +84,7 @@ jobs:
             ./_spidermonkey_install/*
           key: spidermonkey-${{ env.MOZCENTRAL_VERSION }}-${{ runner.os }}-${{ runner.arch }}
       - name: Setup container
-        if: ${{ runner.os == 'Linux' && steps.cache-spidermonkey.outputs.cache-hit != 'true' }}
+        if: ${{ startsWith(matrix.os, 'ubuntu') && steps.cache-spidermonkey.outputs.cache-hit != 'true' }}
         run: |
           apt-get update -y
           apt-get install -y sudo libnss3-dev libssl-dev
@@ -92,7 +92,7 @@ jobs:
           DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata
           echo "AGENT_TOOLSDIRECTORY=/" >> $GITHUB_ENV # do not use the Python installation cached for Ubuntu 22.04
       - name: Setup Python
-        if: ${{ runner.os == 'Linux' && steps.cache-spidermonkey.outputs.cache-hit != 'true' }}
+        if: ${{ startsWith(matrix.os, 'ubuntu') && steps.cache-spidermonkey.outputs.cache-hit != 'true' }}
         run: |
           # Use pyenv to install Python version that is not available via `actions/setup-python`
           unset PYENV_ROOT
@@ -106,7 +106,7 @@ jobs:
         env:
           PYTHON_VERSION: ${{ matrix.python_version }}
       - uses: actions/setup-python@v5
-        if: ${{ runner.os != 'Linux' && steps.cache-spidermonkey.outputs.cache-hit != 'true' }}
+        if: ${{ !startsWith(matrix.os, 'ubuntu') && steps.cache-spidermonkey.outputs.cache-hit != 'true' }}
         with:
           python-version: ${{ matrix.python_version }}
       - name: Setup XCode
@@ -169,10 +169,10 @@ jobs:
         os: [ 'ubuntu-22.04', 'macos-13', 'macos-14', 'windows-2022', 'ubuntu-22.04-arm' ]
         python_version: [ '3.8', '3.9', '3.10', '3.11', '3.12', '3.13' ]
     runs-on: ${{ matrix.os }}
-    container: ${{ (runner.os == 'Linux' && 'ubuntu:20.04') || null }}
+    container: ${{ (startsWith(matrix.os, 'ubuntu') && 'ubuntu:20.04') || null }}
     steps:
       - name: Setup container
-        if: ${{ runner.os == 'Linux' }}
+        if: ${{ startsWith(matrix.os, 'ubuntu') }}
         run: |
           apt-get update -y
           apt-get install -y sudo libnss3-dev libssl-dev
@@ -196,7 +196,7 @@ jobs:
           fetch-depth: 0 # fetch all history for all branches and tags
           # poetry-dynamic-versioning needs git tags to produce the correct version number 
       - name: Setup Python
-        if: ${{ runner.os == 'Linux' }}
+        if: ${{ startsWith(matrix.os, 'ubuntu') }}
         run: |
           # Use pyenv to install Python version that is not available via `actions/setup-python`
           unset PYENV_ROOT
@@ -210,7 +210,7 @@ jobs:
         env:
           PYTHON_VERSION: ${{ matrix.python_version }}
       - uses: actions/setup-python@v5
-        if: ${{ runner.os != 'Linux' }}
+        if: ${{ !startsWith(matrix.os, 'ubuntu') }}
         with:
           python-version: ${{ matrix.python_version }}
       - name: Setup Poetry

--- a/.github/workflows/test-and-publish.yaml
+++ b/.github/workflows/test-and-publish.yaml
@@ -183,11 +183,12 @@ jobs:
         if: ${{ runner.os == 'Linux' }}
         run: |
           # Use pyenv to install Python version that is not available via `actions/setup-python`
+          unset PYENV_ROOT
           curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash
           echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc
           echo '[[ -d $PYENV_ROOT/bin ]] && export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc
           echo 'eval "$(pyenv init - bash)"' >> ~/.bashrc
-          source ~/.bashrc
+          export PATH="$HOME/.pyenv/bin:$PATH"
           pyenv install $PYTHON_VERSION
           pyenv global $PYTHON_VERSION
         env:


### PR DESCRIPTION
CI: Setup Python using pyenv to support building on older arm64 Ubuntu.
The `actions/setup-python` action only supports installing on arm64 Ubuntu 22.04