### PR TITLE
fix(event-loop): release job wrapper ref after scheduling

### DIFF
--- a/src/PyEventLoop.cc
+++ b/src/PyEventLoop.cc
@@ -74,6 +74,7 @@ PyEventLoop::AsyncHandle PyEventLoop::enqueue(PyObject *jobFn) {
   // Enqueue job to the Python event-loop
   //    https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.loop.call_soon
   PyObject *asyncHandle = PyObject_CallMethod(_loop, "call_soon_threadsafe", "O", wrapper);
+  Py_DECREF(wrapper); // the Handle owns the wrapper now; release our ref so jobFn is freed after the job runs
   return PyEventLoop::AsyncHandle(asyncHandle);
 }
 
@@ -82,6 +83,7 @@ static PyObject *_enqueueWithDelay(PyObject *_loop, PyEventLoop::AsyncHandle::id
   // Schedule job to the Python event-loop
   //    https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.loop.call_later
   PyObject *asyncHandle = PyObject_CallMethod(_loop, "call_later", "dOOIdb", delaySeconds, wrapper, _loop, handleId, delaySeconds, repeat); // https://docs.python.org/3/c-api/arg.html#c.Py_BuildValue
+  Py_DECREF(wrapper); // the TimerHandle now owns the wrapper; release our creation ref
   if (!asyncHandle) {
     return nullptr; // RuntimeError
   }

--- a/tests/python/test_event_loop.py
+++ b/tests/python/test_event_loop.py
@@ -1,6 +1,7 @@
 import pytest
 import pythonmonkey as pm
 import asyncio
+import gc
 
 
 def test_setTimeout_unref():
@@ -433,3 +434,20 @@ def test_webassembly():
     # making sure the async_fn is run
     return True
   assert asyncio.run(async_fn())
+
+
+def test_promise_jobs_release_job_wrappers():
+  schedule = pm.eval("() => Promise.resolve().then(() => 0)")
+  awaits = 50
+
+  async def drive():
+    for _ in range(awaits):
+      await schedule()
+    return sum(1 for o in gc.get_objects()
+               if getattr(o, "__name__", "") == "eventLoopJobWrapper")
+
+  leaked = asyncio.run(drive())
+  assert leaked == 0, (
+    f"{leaked} eventLoopJobWrapper objects retained after {awaits} awaits; "
+    f"each settled promise job's wrapper must be released once the job has run"
+  )


### PR DESCRIPTION
## What

Add the missing Py_DECREF on the job wrapper in PyEventLoop::enqueue and _enqueueWithDelay, plus a regression test.

## Why

The wrapper is passed to call_soon_threadsafe / call_later with the "O" format, so the returned Handle / TimerHandle takes its own reference and holds the wrapper until the job runs. The wrapper's creation reference was never released, so the wrapper — and the JS job closure it owns via m_self — leaked once per scheduled promise job and accumulated for the life of the interpreter. The added Py_DECREF drops only that creation reference; the handle's own reference keeps the wrapper alive until the job runs, and the wrapper's normal teardown releases jobFn.

## Reproduction

I compiled a [gist with reproduction details](https://gist.github.com/steinnes/0093059d9cce8f0e12f0fb4bc90ed820) which should demonstrate the leak.

I ran into this when converting spreadsheets to JSON using a library which unzips the .xlsx file using an asynchronous library and I saw the used memory grow by about 200-300MB with every file I processed.

## P.S.

Thanks for an amazing library, I hope I didn't misunderstand the underlying issue, and I'd be happy to change the approach if necessary.